### PR TITLE
enable prompt for all configured roles

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
+	"github.com/segmentio/aws-okta/lib/util"
 	"github.com/spf13/cobra"
 )
 
@@ -55,12 +56,12 @@ func add(cmd *cobra.Command, args []string) error {
 
 	// Ask Okta organization details if not given in command line argument
 	if oktaDomain == "" {
-		organization, err = lib.Prompt("Okta organization", false)
+		organization, err = util.Prompt("Okta organization", false)
 		if err != nil {
 			return err
 		}
 
-		oktaRegion, err = lib.Prompt("Okta region ([us], emea, preview)", false)
+		oktaRegion, err = util.Prompt("Okta region ([us], emea, preview)", false)
 		if err != nil {
 			return err
 		}
@@ -74,7 +75,7 @@ func add(cmd *cobra.Command, args []string) error {
 		}
 		defaultOktaDomain := fmt.Sprintf("%s.%s", organization, tld)
 
-		oktaDomain, err = lib.Prompt("Okta domain ["+defaultOktaDomain+"]", false)
+		oktaDomain, err = util.Prompt("Okta domain ["+defaultOktaDomain+"]", false)
 		if err != nil {
 			return err
 		}
@@ -84,14 +85,14 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 
 	if username == "" {
-		username, err = lib.Prompt("Okta username", false)
+		username, err = util.Prompt("Okta username", false)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Ask for password from prompt
-	password, err := lib.Prompt("Okta password", true)
+	password, err := util.Prompt("Okta password", true)
 	if err != nil {
 		return err
 	}

--- a/lib/keyring.go
+++ b/lib/keyring.go
@@ -4,10 +4,11 @@ import (
 	"os"
 
 	"github.com/99designs/keyring"
+	"github.com/segmentio/aws-okta/lib/util"
 )
 
 func keyringPrompt(prompt string) (string, error) {
-	return PromptWithOutput(prompt, true, os.Stderr)
+	return util.PromptWithOutput(prompt, true, os.Stderr)
 }
 
 func OpenKeyring(allowedBackends []keyring.BackendType) (kr keyring.Keyring, err error) {

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -163,7 +163,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 
 	profileARN, ok := p.profiles[source]["role_arn"]
 	if !ok {
-		return sts.Credentials{}, errors.New("Source profile must provide `role_arn`")
+		profileARN = ""
 	}
 
 	provider := OktaProvider{
@@ -194,7 +194,7 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 
 	profileARN, ok := p.profiles[source]["role_arn"]
 	if !ok {
-		return &url.URL{}, errors.New("Source profile must provide `role_arn`")
+		profileARN = ""
 	}
 
 	provider := OktaProvider{

--- a/lib/saml/roles.go
+++ b/lib/saml/roles.go
@@ -1,0 +1,93 @@
+package saml
+
+import (
+	"errors"
+	"fmt"
+	"github.com/segmentio/aws-okta/lib/util"
+	"strconv"
+	"strings"
+)
+
+func (roleList *AssumableRoles) GetRole(profileARN string) (string, string, error) {
+
+	// if the user doesn't have any roles they can assume return an error.
+	if len(roleList.Roles) == 0 {
+		return "", "", fmt.Errorf("There are no roles that can be assumed")
+	}
+
+	// A role arn was provided as part of the profile, we will assume that role.
+	if profileARN != "" {
+		for _, arole := range roleList.Roles {
+			if profileARN == arole.Role {
+				return arole.Role, arole.Principal, nil
+			}
+		}
+		return "", "", fmt.Errorf("ARN isn't valid")
+	}
+
+	// if the user only has one role assume that role without prompting.
+	if len(roleList.Roles) == 1 {
+		return roleList.Roles[0].Role, roleList.Roles[0].Principal, nil
+	}
+
+	for i, arole := range roleList.Roles {
+		fmt.Printf("%d - %s\n", i, arole.Role)
+	}
+
+	i, err := util.Prompt("Select Role to Assume", false)
+	if err != nil {
+		return "", "", err
+	}
+	if i == "" {
+		return "", "", errors.New("Invalid selection - Please use an option that is listed")
+	}
+	factorIdx, err := strconv.Atoi(i)
+	if err != nil {
+		return "", "", err
+	}
+	if factorIdx > (len(roleList.Roles) - 1) {
+		return "", "", errors.New("Invalid selection - Please use an option that is listed")
+	}
+	return roleList.Roles[factorIdx].Role, roleList.Roles[factorIdx].Principal, nil
+}
+func (resp *Response) GetAssumableRolesFromSAML() (AssumableRoles, error) {
+	roleList := []AssumableRole{}
+
+	for _, a := range resp.Assertion.AttributeStatement.Attributes {
+		if strings.HasSuffix(a.Name, "SAML/Attributes/Role") {
+			for _, v := range a.AttributeValues {
+				tokens := strings.Split(v.Value, ",")
+				if len(tokens) != 2 {
+					continue
+				}
+
+				// Amazon's documentation suggests that the
+				// Role ARN should appear first in the comma-delimited
+				// set in the Role Attribute that SAML IdP returns.
+				//
+				// See the section titled "An Attribute element with the Name attribute set
+				// to https://aws.amazon.com/SAML/Attributes/Role" on this page:
+				// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html
+				//
+				// In practice, though, Okta SAML integrations with AWS will succeed
+				// with either the role or principal ARN first, and these `if` statements
+				// allow that behavior in this program.
+				if strings.Contains(tokens[0], ":saml-provider/") {
+					// if true, Role attribute is formatted like:
+					// arn:aws:iam::ACCOUNT:saml-provider/provider,arn:aws:iam::account:role/roleName
+					roleList = append(roleList, AssumableRole{Role: tokens[1],
+						Principal: tokens[0]})
+				} else if strings.Contains(tokens[1], ":saml-provider/") {
+					// if true, Role attribute is formatted like:
+					// arn:aws:iam::account:role/roleName,arn:aws:iam::ACCOUNT:saml-provider/provider
+					roleList = append(roleList, AssumableRole{Role: tokens[0],
+						Principal: tokens[1]})
+				} else {
+					return AssumableRoles{}, fmt.Errorf("Unable to get roles from %s", v.Value)
+				}
+
+			}
+		}
+	}
+	return AssumableRoles{Roles: roleList}, nil
+}

--- a/lib/saml/struct.go
+++ b/lib/saml/struct.go
@@ -2,6 +2,15 @@ package saml
 
 import "encoding/xml"
 
+type AssumableRole struct {
+	Role      string
+	Principal string
+}
+
+type AssumableRoles struct {
+	Roles []AssumableRole
+}
+
 type Response struct {
 	XMLName      xml.Name
 	SAMLP        string `xml:"xmlns:samlp,attr"`

--- a/lib/util/prompt.go
+++ b/lib/util/prompt.go
@@ -1,4 +1,4 @@
-package lib
+package util
 
 import (
 	"bufio"

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -3,50 +3,10 @@ package lib
 import (
 	"encoding/base64"
 	"encoding/xml"
-	"fmt"
 	"strings"
 
-	"github.com/segmentio/aws-okta/lib/saml"
 	"golang.org/x/net/html"
 )
-
-//TODO: Move those functions into saml package
-
-func GetRoleFromSAML(resp *saml.Response, profileARN string) (string, string, error) {
-	for _, a := range resp.Assertion.AttributeStatement.Attributes {
-		if strings.HasSuffix(a.Name, "SAML/Attributes/Role") {
-			for _, v := range a.AttributeValues {
-				tokens := strings.Split(v.Value, ",")
-				if len(tokens) != 2 {
-					continue
-				}
-
-				// Amazon's documentation suggests that the
-				// Role ARN should appear first in the comma-delimited
-				// set in the Role Attribute that SAML IdP returns.
-				//
-				// See the section titled "An Attribute element with the Name attribute set
-				// to https://aws.amazon.com/SAML/Attributes/Role" on this page:
-				// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html
-				//
-				// In practice, though, Okta SAML integrations with AWS will succeed
-				// with either the role or principal ARN first, and these `if` statements
-				// allow that behavior in this program.
-				if tokens[0] == profileARN {
-					// if true, Role attribute is formatted like:
-					// arn:aws:iam::account:role/roleName,arn:aws:iam::ACCOUNT:saml-provider/provider
-					return tokens[1], tokens[0], nil
-				} else if tokens[1] == profileARN {
-					// if true, Role attribute is formatted like:
-					// arn:aws:iam::ACCOUNT:saml-provider/provider,arn:aws:iam::account:role/roleName
-					return tokens[0], tokens[1], nil
-				}
-			}
-		}
-	}
-
-	return "", "", fmt.Errorf("Role '%s' not authorized by Okta.  Contact Okta admin to make sure that the AWS app is configured properly.", profileARN)
-}
 
 func ParseSAML(body []byte, resp *SAMLAssertion) (err error) {
 	var val string


### PR DESCRIPTION
If `role_arn` is empty or not present and the list of roles is longer
than 1 role. Prompt the user for the role.