### PR TITLE
Remove instructions to download via brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ $ go get github.com/segmentio/aws-okta
 
 [See the wiki for more installation options like Linux packages and precompiled binaries.](https://github.com/segmentio/aws-okta/wiki/Installation)
 
-### MacOS
-
-You can install with `brew`:
-
-```bash
-$ brew install aws-okta
-```
-
 ### Windows
 
 See [docs/windows.md](docs/windows.md) for information on getting this working with Windows.


### PR DESCRIPTION
We had a user try to download via brew instead of the latest au release after reading the Readme. I recommend removing this just to avoid this confusion in the future.