### PR TITLE
refactor lib to support other Okta Providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 packagecloud.conf.json
 aws-okta
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,20 @@ VERSION := $(shell git describe --tags --always --dirty="-dev")
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
 
 test:
-	GO111MODULE=on go test -mod=vendor -v ./...
+	GO111MODULE=on go test -mod=vendor -covermode=count -coverprofile=coverage.out -v ./...
+	@echo
+	@echo INFO: to launch the coverage report: go tool cover -html=coverage.out
+##
+## More information about cover reports:
+## https://blog.golang.org/cover
 
 all: dist/aws-okta-$(VERSION)-darwin-amd64 dist/aws-okta-$(VERSION)-linux-amd64
+linux: dist/aws-okta-$(VERSION)-linux-amd64
+darwin: dist/aws-okta-$(VERSION)-darwin-amd64
 
 clean:
 	rm -rf ./dist
+	rm -f coverage.out
 
 dist/:
 	mkdir -p dist
@@ -24,4 +32,4 @@ dist/aws-okta-$(VERSION)-darwin-amd64: | dist/
 dist/aws-okta-$(VERSION)-linux-amd64: | dist/
 	GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor $(LDFLAGS) -o $@
 
-.PHONY: clean all
+.PHONY: clean all linux darwin test

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
+	"github.com/segmentio/aws-okta/lib2/client"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +71,7 @@ func add(cmd *cobra.Command, args []string) error {
 			oktaRegion = "us"
 		}
 
-		tld, err := lib.GetOktaDomain(oktaRegion)
+		tld, err := client.GetOktaDomain(oktaRegion)
 		if err != nil {
 			return err
 		}
@@ -91,11 +92,11 @@ func add(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	
+
 	if oktaAccountName == "" {
-	    oktaAccountName = "okta-creds"
+		oktaAccountName = "okta-creds"
 	} else {
-	    oktaAccountName = "okta-creds-" + oktaAccountName
+		oktaAccountName = "okta-creds-" + oktaAccountName
 	}
 	log.Debugf("Keyring key: %s", oktaAccountName)
 
@@ -106,11 +107,10 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println()
 
-	creds := lib.OktaCreds{
-		Organization: organization,
-		Username:     username,
-		Password:     password,
-		Domain:       oktaDomain,
+	creds := client.OktaCredential{
+		Username: username,
+		Password: password,
+		Domain:   oktaDomain,
 	}
 
 	// Profiles aren't parsed during `add`, but still want
@@ -118,7 +118,8 @@ func add(cmd *cobra.Command, args []string) error {
 	var dummyProfiles lib.Profiles
 	updateMfaConfig(cmd, dummyProfiles, "", &mfaConfig)
 
-	if err := creds.Validate(mfaConfig); err != nil {
+	oktaClient, err := client.NewOktaClient(creds, nil, mfaConfig)
+	if err := oktaClient.AuthenticateUser(); err != nil {
 		log.Debugf("Failed to validate credentials: %s", err)
 		return ErrFailedToValidateCredentials
 	}

--- a/cmd/cred-process.go
+++ b/cmd/cred-process.go
@@ -9,6 +9,8 @@ import (
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
+	"github.com/segmentio/aws-okta/lib2/client"
+	"github.com/segmentio/aws-okta/lib2/provider"
 	"github.com/spf13/cobra"
 )
 
@@ -69,8 +71,7 @@ func credProcessRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	opts := lib.ProviderOptions{
-		MFAConfig:          mfaConfig,
+	opts := provider.AwsSamlProviderOptions{
 		Profiles:           profiles,
 		SessionDuration:    sessionTTL,
 		AssumeRoleDuration: assumeRoleTTL,
@@ -100,7 +101,9 @@ func credProcessRun(cmd *cobra.Command, args []string) error {
 
 	opts.SessionCacheSingleItem = flagSessionCacheSingleItem
 
-	p, err := lib.NewProvider(kr, profile, opts)
+	oktaCreds, err := client.GetOktaCredentialFromKeyring(kr)
+	oktaClient, err := client.NewOktaClient(oktaCreds, &kr, mfaConfig)
+	p, err := provider.NewAwsSamlProvider(kr, profile, opts, oktaClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
+	"github.com/segmentio/aws-okta/lib2/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -32,7 +33,7 @@ const (
 // global flags
 var (
 	backend                    string
-	mfaConfig                  lib.MFAConfig
+	mfaConfig                  client.MFAConfig
 	debug                      bool
 	version                    string
 	analyticsWriteKey          string
@@ -129,7 +130,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&flagSessionCacheSingleItem, "session-cache-single-item", "", false, fmt.Sprintf("(alpha) Enable single-item session cache; aka %s", envSessionCacheSingleItem))
 }
 
-func updateMfaConfig(cmd *cobra.Command, profiles lib.Profiles, profile string, config *lib.MFAConfig) {
+func updateMfaConfig(cmd *cobra.Command, profiles lib.Profiles, profile string, config *client.MFAConfig) {
 	if !cmd.Flags().Lookup("mfa-duo-device").Changed {
 		mfaDeviceFromEnv, ok := os.LookupEnv("AWS_OKTA_MFA_DUO_DEVICE")
 		if ok {

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/sys v0.0.0-20190710143415-6ec70d6a5542 // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
+	gopkg.in/h2non/gock.v1 v1.0.15
 	gopkg.in/ini.v1 v1.42.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
@@ -44,6 +46,8 @@ github.com/marshallbrekka/go.hid v0.0.0-20161227002717-2c1c4616a9e7 h1:OWtSIWxw/
 github.com/marshallbrekka/go.hid v0.0.0-20161227002717-2c1c4616a9e7/go.mod h1:EKx8PPAql1ncHKW3HCDlw4d7ELZ/kmfiDJjLfNf+Ek0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/segmentio/analytics-go v3.0.1+incompatible h1:W7T3ieNQjPFMb+SE8SAVYo6mPkKK/Y37wYdiNf5lCVg=
@@ -98,5 +102,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+y
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/h2non/gock.v1 v1.0.15 h1:SzLqcIlb/fDfg7UvukMpNcWsu7sI5tWwL+KCATZqks0=
+gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
 gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/lib/config.go
+++ b/lib/config.go
@@ -56,6 +56,10 @@ func (c *fileConfig) Parse() (Profiles, error) {
 	return profiles, nil
 }
 
+func SourceProfile(p string, from Profiles) string {
+	return sourceProfile(p, from)
+}
+
 // sourceProfile returns either the defined source_profile or p if none exists
 func sourceProfile(p string, from Profiles) string {
 	if conf, ok := from[p]; ok {

--- a/lib2/client/okta.go
+++ b/lib2/client/okta.go
@@ -1,0 +1,667 @@
+// Client for making requests to Okta APIs
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/publicsuffix"
+
+	"github.com/99designs/keyring"
+	"github.com/segmentio/aws-okta/lib"
+	"github.com/segmentio/aws-okta/lib/mfa"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	OktaServerUs      = "okta.com"
+	OktaServerEmea    = "okta-emea.com"
+	OktaServerPreview = "oktapreview.com"
+	OktaServerDefault = OktaServerUs
+
+	// deprecated; use OktaServerUs
+	OktaServer = OktaServerUs
+
+	Timeout = time.Duration(60 * time.Second)
+)
+
+type OktaUser struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+type OktaClient struct {
+	creds        OktaCredential
+	UserAuth     *OktaUserAuthn
+	DuoClient    *lib.DuoClient
+	SessionToken string
+	Expiration   time.Time
+	CookieJar    http.CookieJar
+	BaseURL      *url.URL
+	MFAConfig    MFAConfig
+	Keyring      *keyring.Keyring
+	client       http.Client
+}
+
+type MFAConfig struct {
+	Provider   string // Which MFA provider to use when presented with an MFA challenge
+	FactorType string // Which of the factor types of the MFA provider to use
+	DuoDevice  string // Which DUO device to use for DUO MFA
+}
+
+// type: OktaCredential struct stores Okta credentials and domain information that will
+// be used by OktaClient when making API calls to Okta
+type OktaCredential struct {
+	Username string
+	Password string
+	Domain   string
+}
+
+// Checks the validity of OktaCredential and should be called before
+// using the credentials to make API calls.
+//
+// This public method will only validate that credentials exist, it will NOT
+// validate them for correctness. To validate correctness an OktaClient must be
+// used to make a request to Okta.
+func (c *OktaCredential) IsValid() bool {
+	return c.Username != "" && c.Password != "" && c.Domain != ""
+}
+
+// Will fetch your Okta username, password, and domain from your keyring secret
+// backend.
+//
+// Will get the default credentials stored under the `okta-creds` key.
+//
+// feat-request: add support for getting additional sets of credentials.
+// The interface for this functionality needs to be defined, it's
+// possible to then implement alternative credential backends
+// to flexibly support alternative implementations.
+func GetOktaCredentialFromKeyring(kr keyring.Keyring) (OktaCredential, error) {
+	var oktaCreds OktaCredential
+
+	item, err := kr.Get("okta-creds")
+	if err != nil {
+		return oktaCreds, err
+	}
+
+	if err = json.Unmarshal(item.Data, &oktaCreds); err != nil {
+		return oktaCreds, fmt.Errorf("Failed to get okta credentials from your keyring.  Please make sure you have added okta credentials with `aws-okta add`")
+	}
+	return oktaCreds, nil
+}
+
+// looks up the okta domain based on the region. For example, the okta domain
+// for "us" is `okta.com` making your api domain as `<your-org>.okta.com`
+func GetOktaDomain(region string) (string, error) {
+	switch region {
+	case "us":
+		return OktaServerUs, nil
+	case "emea":
+		return OktaServerEmea, nil
+	case "preview":
+		return OktaServerPreview, nil
+	}
+	return "", fmt.Errorf("invalid region %s", region)
+}
+
+// Creates and initializes an OktaClient. This is intended to provide a simple
+// way to create a client that can make requests to the Okta APIs.
+//
+// As an example for how a client might be used:
+// This client can then be passed to a provider that will manage auth
+// for other platforms. Currently AWS SAML provider is supported to get STS
+// credentials to get access to AWS services.
+//
+// Supported configuration options:
+//       TODO: expand on configuration options and add tests.
+//
+// -- proxy config: TBD
+// -- session caching: Passing in a keyring will enable support for caching.
+//      this will cache a valid okta session securely in the keyring. This
+//			session is only for access to the Okta APIs, any additional sessions
+//			(for example, aws STS credentials) will be cached by the provider that
+//      creates them.
+func NewOktaClient(creds OktaCredential, kr *keyring.Keyring, mfaConfig MFAConfig) (*OktaClient, error) {
+
+	if creds.IsValid() {
+		log.Debug("Credentials are valid :", creds.Username, " @ ", creds.Domain)
+	} else {
+		return nil, errors.New("credentials aren't complete. To remedy this, re-add your credentials with `aws-okta add`")
+	}
+
+	// url parse & set base
+	base, err := url.Parse(fmt.Sprintf(
+		"https://%s", creds.Domain,
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		return nil, err
+	}
+
+	transCfg := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: Timeout,
+	}
+
+	client := http.Client{
+		Transport: transCfg,
+		Timeout:   Timeout,
+		Jar:       jar,
+	}
+
+	oktaClient := OktaClient{
+		creds: creds,
+		// remove this now that we're storing the client
+		CookieJar: jar,
+		BaseURL:   base,
+		MFAConfig: mfaConfig,
+		UserAuth:  &OktaUserAuthn{},
+		Keyring:   kr,
+		client:    client,
+	}
+
+	// this can fail if we don't have have a backend defined.
+	// failing to retrived a cached cookie shouldn't fail the entire
+	// operation.
+	err = oktaClient.retrieveSessionCookie()
+	if err != nil {
+		// log the error to debug and continue
+		log.Debug("func:NewOktaClient ", err)
+	}
+	return &oktaClient, nil
+}
+
+// Gets the Okta session cookie and stores it in the cookie jar used by the
+// http client which is used as the primary authentication mechanism.
+//
+// If a keyring isn't provided to the client then an error will be returned.
+// This error indicates that the session wasn't retrieved and should be handled
+// appropriately.
+func (o *OktaClient) retrieveSessionCookie() (err error) {
+
+	if o.Keyring == nil {
+		return fmt.Errorf("Session NOT retrieved. Reason: Session Backend not defined")
+	}
+	cookieItem, err := (*o.Keyring).Get(o.getSessionCookieKeyringKey())
+	if err == nil {
+		o.CookieJar.SetCookies(o.BaseURL, []*http.Cookie{
+			{
+				Name:  "sid",
+				Value: string(cookieItem.Data),
+			},
+		})
+		log.Debug("Using Okta session: ", string(cookieItem.Data))
+	}
+
+	return
+}
+
+// returns the sesion key that is username and domain aware.
+func (o *OktaClient) getSessionCookieKeyringKey() string {
+	return "okta-session-cookie-" + o.creds.Username + "-" + o.creds.Domain
+}
+
+// Takes a session cookie in the cookie jar and saves it in the keychain,
+// this allows it to be used across invocations where the client making the
+// request is destroyed/created between requests.
+func (o *OktaClient) SaveSessionCookie() (err error) {
+
+	if o.Keyring == nil {
+		return fmt.Errorf("Session NOT saved. Reason: Session Backend not defined")
+	}
+	cookies := o.CookieJar.Cookies(o.BaseURL)
+	for _, cookie := range cookies {
+		if cookie.Name == "sid" {
+			newCookieItem := keyring.Item{
+				Key:                         o.getSessionCookieKeyringKey(),
+				Data:                        []byte(cookie.Value),
+				Label:                       "okta session cookie for " + o.creds.Username,
+				KeychainNotTrustApplication: false,
+			}
+			err = (*o.Keyring).Set(newCookieItem)
+			if err != nil {
+				return
+			}
+			log.Debug("Saving Okta Session Cookie: ", cookie.Value)
+		}
+	}
+	return
+}
+
+// Sends a request to the Okta Sessions API to validate if the session cookie
+// is valid or not. This doesn't always mean that the session can be used for
+// all Okta applications but it does accurately fetch the state of the session.
+func (o *OktaClient) ValidateSession() (sessionValid bool, err error) {
+	var mySessionResponse *http.Response
+	sessionValid = false
+
+	log.Debug("Checking if we have a valid Okta session")
+	mySessionResponse, err = o.Request("GET", "api/v1/sessions/me", url.Values{}, []byte{}, "json", false)
+	if err != nil {
+		return
+	}
+	defer mySessionResponse.Body.Close()
+
+	// https://developer.okta.com/docs/reference/api/sessions/#get-current-session
+	// "if the session is invalid, a 404 Not Found response will be returned."
+	// checking for ok status (200) is adequate to see if the session is still valid.
+	sessionValid = mySessionResponse.StatusCode == http.StatusOK
+
+	return
+}
+
+// Will authenticate a user and create a new session. Depending on how the Okta
+// domain is configured MFA may be requested. Authentication flow supports
+// several different MFA types including:
+//
+// SMS: Okta will send an SMS to the user that includes a code that needs to be
+//      sent back as the verify step.
+// PUSH: Either OKTA verify or DUO are supported.
+// U2F: a u2f hardware token, eg. Yubikey
+//
+// TODO: document full list of MFA supported and create tests
+//
+// More details about the auth flow implemented by this client can be found in
+// Okta documentation: https://developer.okta.com/docs/reference/api/authn
+//
+func (o *OktaClient) AuthenticateUser() (err error) {
+	var payload []byte
+	//TODO(switj): cleanup this marshal struct
+	payload, err = json.Marshal(OktaUser{Username: o.creds.Username, Password: o.creds.Password})
+	if err != nil {
+		return
+	}
+
+	log.Debug("Posting first call to authenticate the user.")
+	res, err := o.Request("POST", "api/v1/authn", url.Values{}, payload, "json", true)
+	if err != nil {
+		return fmt.Errorf("Failed to authenticate with okta. If your credentials have changed, use 'aws-okta add': %#v", err)
+	}
+	defer res.Body.Close()
+
+	err = json.NewDecoder(res.Body).Decode(&o.UserAuth)
+	if err != nil {
+		return
+	}
+	// Step 2 : Challenge MFA if needed
+	if o.UserAuth.Status == "MFA_REQUIRED" {
+		log.Info("Requesting MFA. Please complete two-factor authentication with your second device")
+		if err = o.challengeMFA(); err != nil {
+			return
+		}
+	} else if o.UserAuth.Status == "PASSWORD_EXPIRED" {
+		return fmt.Errorf("Password is expired, login to Okta console to change")
+	}
+
+	if o.UserAuth.SessionToken == "" {
+		log.Debug("Auth failed. Reason: Session token isn't present.")
+		return fmt.Errorf("authentication failed for %s", o.creds.Username)
+	}
+	return
+}
+
+// Public interface to get the Okta session token.
+func (o *OktaClient) GetSessionToken() string {
+	return o.UserAuth.SessionToken
+}
+
+// Validates the provided MFA config matches what the user has configured in
+// Okta. If the provided config doesn't match an error will be returned.
+func selectMFADeviceFromConfig(o *OktaClient) (*OktaUserAuthnFactor, error) {
+	log.Debugf("MFAConfig: %v\n", o.MFAConfig)
+	if o.MFAConfig.Provider == "" || o.MFAConfig.FactorType == "" {
+		return nil, nil
+	}
+
+	for _, f := range o.UserAuth.Embedded.Factors {
+		log.Debugf("%v\n", f)
+		if strings.EqualFold(f.Provider, o.MFAConfig.Provider) && strings.EqualFold(f.FactorType, o.MFAConfig.FactorType) {
+			log.Debugf("Using matching factor \"%v %v\" from config\n", f.Provider, f.FactorType)
+			return &f, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Failed to select MFA device with Provider = \"%s\", FactorType = \"%s\"", o.MFAConfig.Provider, o.MFAConfig.FactorType)
+}
+
+// Will prompt the user to select one of the configured MFA devices if an MFA
+// configuration isn't provided.
+//
+// TODO: convert this to a passed io reader to facilitate simple testing.
+func (o *OktaClient) selectMFADevice() (*OktaUserAuthnFactor, error) {
+	factors := o.UserAuth.Embedded.Factors
+	if len(factors) == 0 {
+		return nil, errors.New("No available MFA Factors")
+	} else if len(factors) == 1 {
+		return &factors[0], nil
+	}
+
+	factor, err := selectMFADeviceFromConfig(o)
+	if err != nil {
+		return nil, err
+	}
+
+	if factor != nil {
+		return factor, nil
+	}
+
+	log.Info("Select a MFA from the following list")
+	for i, f := range factors {
+		log.Infof("%d: %s (%s)", i, f.Provider, f.FactorType)
+	}
+	i, err := lib.Prompt("Select MFA method", false)
+	if i == "" {
+		return nil, errors.New("Invalid selection - Please use an option that is listed")
+	}
+	if err != nil {
+		return nil, err
+	}
+	factorIdx, err := strconv.Atoi(i)
+	if err != nil {
+		return nil, err
+	}
+	if factorIdx > (len(factors) - 1) {
+		return nil, errors.New("Invalid selection - Please use an option that is listed")
+	}
+	return &factors[factorIdx], nil
+}
+
+// Makes any initial requests that are needed to verify MFA
+//
+// as an example this would include sending a request for an SMS code.
+func (o *OktaClient) preChallenge(oktaFactorId, oktaFactorType string) ([]byte, error) {
+	var mfaCode string
+	var err error
+
+	//Software and Hardware based OTP Tokens
+	if strings.Contains(oktaFactorType, "token") {
+		log.Debug("Token MFA")
+		mfaCode, err = lib.Prompt("Enter MFA Code", false)
+		if err != nil {
+			return nil, err
+		}
+	} else if strings.Contains(oktaFactorType, "sms") {
+		log.Debug("SMS MFA")
+		payload, err := json.Marshal(OktaStateToken{
+			StateToken: o.UserAuth.StateToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		log.Debug("Requesting SMS Code")
+		res, err := o.Request("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify", url.Values{}, payload, "json", true)
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+
+		mfaCode, err = lib.Prompt("Enter MFA Code from SMS", false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	payload, err := json.Marshal(OktaStateToken{
+		StateToken: o.UserAuth.StateToken,
+		PassCode:   mfaCode,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// executes the second step (if required) of the MFA verifaction process to get
+// a valid session cookie.
+func (o *OktaClient) postChallenge(payload []byte, oktaFactorProvider string, oktaFactorId string) error {
+	//Initiate Push Notification
+	if o.UserAuth.Status == "MFA_CHALLENGE" {
+		f := o.UserAuth.Embedded.Factor
+		errChan := make(chan error, 1)
+
+		if oktaFactorProvider == "DUO" {
+			// Contact the Duo to initiate Push notification
+			if f.Embedded.Verification.Host != "" {
+				o.DuoClient = &lib.DuoClient{
+					Host:       f.Embedded.Verification.Host,
+					Signature:  f.Embedded.Verification.Signature,
+					Callback:   f.Embedded.Verification.Links.Complete.Href,
+					Device:     o.MFAConfig.DuoDevice,
+					StateToken: o.UserAuth.StateToken,
+				}
+
+				log.Debugf("Host:%s\nSignature:%s\nStateToken:%s\n",
+					f.Embedded.Verification.Host, f.Embedded.Verification.Signature,
+					o.UserAuth.StateToken)
+
+				go func() {
+					log.Debug("challenge u2f")
+					log.Info("Sending Push Notification...")
+					err := o.DuoClient.ChallengeU2f(f.Embedded.Verification.Host)
+					if err != nil {
+						errChan <- err
+					}
+				}()
+			}
+		} else if oktaFactorProvider == "FIDO" {
+			f := o.UserAuth.Embedded.Factor
+
+			log.Debug("FIDO U2F Details:")
+			log.Debug("  ChallengeNonce: ", f.Embedded.Challenge.Nonce)
+			log.Debug("  AppId: ", f.Profile.AppId)
+			log.Debug("  CredentialId: ", f.Profile.CredentialId)
+			log.Debug("  StateToken: ", o.UserAuth.StateToken)
+
+			fidoClient, err := mfa.NewFidoClient(f.Embedded.Challenge.Nonce,
+				f.Profile.AppId,
+				f.Profile.Version,
+				f.Profile.CredentialId,
+				o.UserAuth.StateToken)
+			if err != nil {
+				return err
+			}
+
+			signedAssertion, err := fidoClient.ChallengeU2f()
+			if err != nil {
+				return err
+			}
+			// re-assign the payload to provide U2F responses.
+			payload, err = json.Marshal(signedAssertion)
+			if err != nil {
+				return err
+			}
+		}
+		// Poll Okta until authentication has been completed
+		for o.UserAuth.Status != "SUCCESS" {
+			select {
+			case duoErr := <-errChan:
+				log.Printf("Err: %s", duoErr)
+				if duoErr != nil {
+					return fmt.Errorf("Failed Duo challenge. Err: %s", duoErr)
+				}
+			default:
+				res, err := o.Request("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify", url.Values{}, payload, "json", true)
+				if err != nil {
+					return fmt.Errorf("Failed authn verification for okta. Err: %s", err)
+				}
+				defer res.Body.Close()
+
+				err = json.NewDecoder(res.Body).Decode(&o.UserAuth)
+				if err != nil {
+					return err
+				}
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
+	return nil
+}
+
+// helper function to get a url, including path, for an Okta api or app.
+func (o *OktaClient) GetURL(path string) (fullURL *url.URL, err error) {
+
+	fullURL, err = url.Parse(fmt.Sprintf(
+		"%s/%s",
+		o.BaseURL,
+		path,
+	))
+	return
+}
+func (o *OktaClient) challengeMFA() (err error) {
+	var oktaFactorProvider string
+	var oktaFactorId string
+	var payload []byte
+	var oktaFactorType string
+
+	factor, err := o.selectMFADevice()
+	if err != nil {
+		log.Debug("Failed to select MFA device")
+		return
+	}
+	oktaFactorProvider = factor.Provider
+	if oktaFactorProvider == "" {
+		return
+	}
+	oktaFactorId, err = GetFactorId(factor)
+	if err != nil {
+		return
+	}
+	oktaFactorType = factor.FactorType
+	if oktaFactorId == "" {
+		return
+	}
+	log.Debugf("Okta Factor Provider: %s", oktaFactorProvider)
+	log.Debugf("Okta Factor ID: %s", oktaFactorId)
+	log.Debugf("Okta Factor Type: %s", oktaFactorType)
+
+	payload, err = o.preChallenge(oktaFactorId, oktaFactorType)
+
+	res, err := o.Request("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify", url.Values{}, payload, "json", true)
+	if err != nil {
+		return fmt.Errorf("Failed authn verification for okta. Err: %s", err)
+	}
+	defer res.Body.Close()
+
+	err = json.NewDecoder(res.Body).Decode(&o.UserAuth)
+	if err != nil {
+		return
+	}
+
+	//Handle Push Notification
+	err = o.postChallenge(payload, oktaFactorProvider, oktaFactorId)
+	if err != nil {
+		return err
+	}
+	return
+}
+
+// gets the factor ID that uniquely identifies an MFA device.
+func GetFactorId(f *OktaUserAuthnFactor) (id string, err error) {
+	switch f.FactorType {
+	case "web":
+		id = f.Id
+	case "token":
+		if f.Provider == "SYMANTEC" {
+			id = f.Id
+		} else {
+			err = fmt.Errorf("provider %s with factor token not supported", f.Provider)
+		}
+	case "token:software:totp":
+		id = f.Id
+	case "token:hardware":
+		id = f.Id
+	case "sms":
+		id = f.Id
+	case "u2f":
+		id = f.Id
+	case "push":
+		if f.Provider == "OKTA" || f.Provider == "DUO" {
+			id = f.Id
+		} else {
+			err = fmt.Errorf("provider %s with factor push not supported", f.Provider)
+		}
+	default:
+		err = fmt.Errorf("factor %s not supported", f.FactorType)
+	}
+	return
+}
+
+// Makes a request to Okta.
+//
+// Supports Core okta APIs or Okta apps that extend the Okta functionaliy.
+//
+// Options:
+// -- method. the http method to use.
+// -- path. the url path to use.
+// -- queryParams. the query parameters to use in the request.
+// -- data. the data that will be sent as part of the request body.
+// -- format. use to set the encoding format header.
+// -- followRedirects. will change the http client configuration to follow
+//                     redirects or not.
+//
+// TODO: refactor this method signature to clarify the interface.
+// something like:
+// -- method.
+// -- url.URL (including RawParams).
+// -- requestBody.
+// -- clientOptions. this would include things like encoding and follow redirects
+func (o *OktaClient) Request(method string, path string, queryParams url.Values, data []byte, format string, followRedirects bool) (res *http.Response, err error) {
+	var header http.Header
+
+	requestUrl, err := url.Parse(fmt.Sprintf(
+		"%s/%s", o.BaseURL, path,
+	))
+	if err != nil {
+		return
+	}
+	requestUrl.RawQuery = queryParams.Encode()
+
+	if format == "json" {
+		header = http.Header{
+			"Accept":        []string{"application/json"},
+			"Content-Type":  []string{"application/json"},
+			"Cache-Control": []string{"no-cache"},
+		}
+	} else {
+		// disable gzip encoding; it was causing spurious EOFs
+		// for some users; see #148
+		header = http.Header{
+			"Accept-Encoding": []string{"identity"},
+		}
+	}
+
+	var checkRedirectFunc func(req *http.Request, via []*http.Request) error
+	if !followRedirects {
+		checkRedirectFunc = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+	o.client.CheckRedirect = checkRedirectFunc
+
+	req := &http.Request{
+		Method:        method,
+		URL:           requestUrl,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        header,
+		Body:          ioutil.NopCloser(bytes.NewReader(data)),
+		ContentLength: int64(len(data)),
+	}
+	log.Debug(method, " ", requestUrl.String())
+
+	res, err = o.client.Do(req)
+	return
+}

--- a/lib2/client/okta_test.go
+++ b/lib2/client/okta_test.go
@@ -1,0 +1,512 @@
+package client
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/99designs/keyring"
+	"github.com/stretchr/testify/assert"
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+func TestOktaClientHappy(t *testing.T) {
+	var (
+		oktaClient *OktaClient
+		creds      OktaCredential
+		err        error
+		Kr         keyring.Keyring
+		KrBackend  []keyring.BackendType
+	)
+
+	defer gock.Off()
+
+	// uncomment this to get gock to dump all requests
+	//	gock.Observe(gock.DumpRequest)
+
+	//
+	// start setup
+	//
+	creds = OktaCredential{
+		Domain:   "canada",
+		Username: "john",
+		Password: "johnnyjohn123",
+	}
+	// we use a file backend for testing in /tmp/
+	KrBackend = append(KrBackend, keyring.FileBackend)
+	tempDir, err := ioutil.TempDir("", "aws-okta")
+	assert.NoError(t, err, "create a temp dir to back the keyring")
+	Kr, err = keyring.Open(keyring.Config{
+		AllowedBackends:          KrBackend,
+		KeychainTrustApplication: true,
+		ServiceName:              "aws-okta-login",
+		LibSecretCollectionName:  "awsvault",
+		FileDir:                  tempDir,
+		FilePasswordFunc:         func(string) (string, error) { return "funkypass", nil }})
+	assert.NoError(t, err, "No errors when opening a keyring")
+
+	oktaClient, err = NewOktaClient(creds, &Kr, MFAConfig{})
+	assert.NoError(t, err, "No errors when creating a client")
+
+	// intercept the http client with gock to mock out the Okta responses
+	gock.InterceptClient(&(oktaClient.client))
+
+	//
+	// end setup
+	//
+
+	t.Run("validate okta client", func(t *testing.T) {
+		assert.NotNil(t, oktaClient.BaseURL, "BaseURL is set")
+		assert.Equal(t, "https://canada", oktaClient.BaseURL.String(), "Base URL should match")
+	})
+
+	t.Run("KeyringKey includes username", func(t *testing.T) {
+		keyringKey := oktaClient.getSessionCookieKeyringKey()
+		assert.Equal(t, "okta-session-cookie-john-canada", keyringKey, "session should be keyed on username")
+	})
+
+	t.Run("session tests", func(t *testing.T) {
+		tokenData := "johnnyToken"
+		krItem := keyring.Item{
+			Key:                         oktaClient.getSessionCookieKeyringKey(),
+			Data:                        []byte(tokenData),
+			Label:                       "okta testing cookie",
+			KeychainNotTrustApplication: false,
+		}
+		err = Kr.Set(krItem)
+		assert.NoError(t, err, "Set keyring item")
+
+		err = oktaClient.retrieveSessionCookie()
+		if assert.NoError(t, err, "Can retrieve sessions without errors") {
+			assert.Equal(t, tokenData, oktaClient.CookieJar.Cookies(oktaClient.BaseURL)[0].Value, "Base URL should match")
+		}
+
+		tokenData = "newTokenData"
+		oktaClient.CookieJar.SetCookies(oktaClient.BaseURL, []*http.Cookie{
+			{
+				Name:  "sid",
+				Value: string(tokenData),
+			},
+		})
+		err = oktaClient.SaveSessionCookie()
+		if assert.NoError(t, err, "Can save sessions without errors") {
+
+			assert.Equal(t, tokenData, oktaClient.CookieJar.Cookies(oktaClient.BaseURL)[0].Value, "Base URL should match")
+		}
+	})
+	t.Run("test okta session validity", func(t *testing.T) {
+		gock.New("https://canada").
+			Get("/api/v1/sessions/me").
+			Reply(200)
+		isSessionValid, err := oktaClient.ValidateSession()
+		if assert.NoError(t, err, "We can validate a session") {
+			assert.Equal(t, true, isSessionValid, "Assert the session is valid if 200 returned")
+		}
+		gock.New("https://canada").
+			Get("/api/v1/sessions/me").
+			Reply(400)
+		isSessionValid, err = oktaClient.ValidateSession()
+		if assert.NoError(t, err, "We can validate a session") {
+			assert.Equal(t, false, isSessionValid, "Assert the session is NOT valid if !200 returned")
+		}
+
+	})
+
+	t.Run("test okta user auth flow no MFA", func(t *testing.T) {
+		gock.New("https://canada").
+			Post("/api/v1/authn").
+			JSON(map[string]string{"username": creds.Username, "password": creds.Password}).
+			Reply(200).BodyString(`{
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "status": "SUCCESS",
+  "relayState": "/myapp/some/deep/link/i/want/to/return/to",
+  "sessionToken": "this-is-my-kebab-token",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    }
+  }
+}`)
+		err = oktaClient.AuthenticateUser()
+		if assert.NoError(t, err, "We're able to auth without MFA") {
+
+			assert.Equal(t, "this-is-my-kebab-token", oktaClient.UserAuth.SessionToken, "we're able to get a sessions token from the response")
+		}
+	})
+}
+
+func TestOktaClientNoSessionCache(t *testing.T) {
+	var (
+		oktaClient *OktaClient
+		creds      OktaCredential
+		err        error
+		//		mfaConfig  MFAConfig
+	)
+
+	defer gock.Off()
+
+	// uncomment this to get gock to dump all requests
+	//	gock.Observe(gock.DumpRequest)
+
+	//
+	// start setup
+	//
+	creds = OktaCredential{
+		Domain:   "canada",
+		Username: "john",
+		Password: "johnnyjohn123",
+	}
+	oktaClient, err = NewOktaClient(creds, nil, MFAConfig{})
+	assert.NoError(t, err, "No errors when creating a client")
+
+	// intercept the http client with gock to mock out the Okta responses
+	gock.InterceptClient(&(oktaClient.client))
+
+	//
+	// end setup
+	//
+	t.Run("test okta user auth flow no MFA", func(t *testing.T) {
+		gock.New("https://canada").
+			Post("/api/v1/authn").
+			JSON(map[string]string{"username": creds.Username, "password": creds.Password}).
+			Reply(200).BodyString(`{
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "status": "SUCCESS",
+  "relayState": "/myapp/some/deep/link/i/want/to/return/to",
+  "sessionToken": "this-is-my-kebab-token",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    }
+  }
+}`)
+		err = oktaClient.AuthenticateUser()
+		if assert.NoError(t, err, "We're able to auth without MFA") {
+
+			assert.Equal(t, "this-is-my-kebab-token", oktaClient.UserAuth.SessionToken, "we're able to get a sessions token from the response")
+		}
+	})
+
+	t.Run("test okta user auth flow with MFA", func(t *testing.T) {
+		gock.New("https://canada").
+			Post("/api/v1/authn").
+			JSON(map[string]string{"username": creds.Username, "password": creds.Password}).
+			Reply(200).BodyString(`{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "status": "MFA_REQUIRED",
+  "relayState": "/myapp/some/deep/link/i/want/to/return/to",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factors": [
+      {
+        "id": "fuf8y2l4n5mfH0UWe0h7",
+        "factorType": "u2f",
+        "provider": "FIDO",
+        "profile": {
+          "credentialId": "dade.murphy@example.com"
+        },
+        "_links": {
+          "verify": {
+            "href": "https://${yourOktaDomain}/api/v1/authn/factors/rsalhpMQVYKHZKXZJQEW/verify",
+            "hints": {
+              "allow": [
+                "POST"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "cancel": {
+      "href": "https://${yourOktaDomain}/api/v1/authn/cancel",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}`)
+
+		gock.New("https://canada").
+			Post("/api/v1/authn/factors/fuf8y2l4n5mfH0UWe0h7/verify").
+			Reply(200).BodyString(`{
+   "stateToken":"00wCfuPA3qX3azDawSdPGFIhHuzbZX72Gv4bu_ew9d",
+   "expiresAt":"2016-12-06T01:32:39.000Z",
+   "status":"MFA_CHALLENGE",
+   "_embedded":{
+      "user":{
+         "id":"00u21eb3qyRDNNIKTGCW",
+         "passwordChanged":"2015-10-28T23:27:57.000Z",
+         "profile":{
+            "login":"first.last@gmail.com",
+            "firstName":"First",
+            "lastName":"Last",
+            "locale":"en",
+            "timeZone":"America/Los_Angeles"
+         }
+      },
+      "factor":{
+         "id":"fuf8y2l4n5mfH0UWe0h7",
+         "factorType":"u2f",
+         "provider":"FIDO",
+         "vendorName":"FIDO",
+         "profile":{
+            "credentialId":"shvjvW2Fi2GtCJb33nm0105EISG9lf2Jg0jWl42URM6vtDH8-AhnoSKfpoHfAf0kJMaCx13glfdxiLFuPW_1bw",
+            "appId":"https://${yourOktaDomain}",
+            "version":"U2F_V2"
+         },
+         "_embedded":{
+            "challenge":{
+               "nonce":"tT1MI7XGzMu48Ivnz3vB",
+               "timeoutSeconds":20
+            }
+         }
+      },
+      "policy":{
+         "allowRememberDevice":true,
+         "rememberDeviceLifetimeInMinutes":0,
+         "rememberDeviceByDefault":false
+      }
+   },
+   "_links":{
+      "next":{
+         "name":"verify",
+         "href":"https://${yourOktaDomain}/api/v1/authn/factors/fuf8y2l4n5mfH0UWe0h7/verify",
+         "hints":{
+            "allow":[
+               "POST"
+            ]
+         }
+      },
+      "cancel":{
+         "href":"https://${yourOktaDomain}/api/v1/authn/cancel",
+         "hints":{
+            "allow":[
+               "POST"
+            ]
+         }
+      },
+      "prev":{
+         "href":"https://${yourOktaDomain}/api/v1/authn/previous",
+         "hints":{
+            "allow":[
+               "POST"
+            ]
+         }
+      }
+   }
+}`)
+
+		oktaClient.MFAConfig = MFAConfig{
+			Provider:   "YUBIKEY",
+			FactorType: "u2f",
+		}
+		err = oktaClient.AuthenticateUser()
+		t.Skip("Skip MFA test")
+		if assert.NoError(t, err, "We're able to auth with MFA") {
+
+			assert.Equal(t, "this-is-my-kebab-token", oktaClient.UserAuth.SessionToken, "we're able to get a sessions token from the response")
+		}
+	})
+	t.Run("okta user auth, expired password flow no MFA", func(t *testing.T) {
+		gock.New("https://canada").
+			Post("/api/v1/authn").
+			JSON(map[string]string{"username": creds.Username, "password": creds.Password}).
+			Reply(200).BodyString(`{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "status": "PASSWORD_EXPIRED",
+  "relayState": "/myapp/some/deep/link/i/want/to/return/to",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "policy": {
+      "complexity": {
+        "minLength": 8,
+        "minLowerCase": 1,
+        "minUpperCase": 1,
+        "minNumber": 1,
+        "minSymbol": 0
+      }
+    }
+  },
+  "_links": {
+    "next": {
+      "name": "changePassword",
+      "href": "https://${yourOktaDomain}/api/v1/authn/credentials/change_password",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    },
+    "cancel": {
+      "href": "https://${yourOktaDomain}/api/v1/authn/cancel",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}`)
+		// this would only test the unlikely case where the user doesn't have MFA setup.
+		// https://developer.okta.com/docs/reference/api/authn/#primary-authentication-with-public-application
+		err = oktaClient.AuthenticateUser()
+		assert.Equal(t, fmt.Errorf("Password is expired, login to Okta console to change"), err)
+	})
+
+	t.Run("session interface returns a reasonable error", func(t *testing.T) {
+
+		// refactor(switj): make oktaClient.SaveSessionCookie private
+		err = oktaClient.SaveSessionCookie()
+		assert.Equal(t, err, fmt.Errorf("Session NOT saved. Reason: Session Backend not defined"))
+
+		err = oktaClient.retrieveSessionCookie()
+		assert.Equal(t, err, fmt.Errorf("Session NOT retrieved. Reason: Session Backend not defined"))
+	})
+}
+
+func TestOktaClientUtils(t *testing.T) {
+
+	//
+	// start setup
+	//
+	// ---
+	//
+	// end setup
+	//
+
+	t.Run("valid regions", func(t *testing.T) {
+		domainTests := map[string]string{
+			"us":      "okta.com",
+			"emea":    "okta-emea.com",
+			"preview": "oktapreview.com",
+		}
+		for region, expectedDomain := range domainTests {
+			oktaDomain, err := GetOktaDomain(region)
+			if assert.NoError(t, err, "Got an error while using a valid region") {
+				assert.Equal(t, expectedDomain, oktaDomain)
+			}
+		}
+	})
+
+	t.Run("invalid regions", func(t *testing.T) {
+		domainTests := map[string]error{
+			"canada": fmt.Errorf("invalid region %s", "canada"),
+		}
+
+		for region, expectedError := range domainTests {
+			_, err := GetOktaDomain(region)
+			assert.Equal(t, expectedError, err, "We get the correct error for invalid domains")
+		}
+	})
+
+	t.Run("MFA Factor id lookup success cases", func(t *testing.T) {
+		mfaIdTests := map[string]OktaUserAuthnFactor{
+			"web": OktaUserAuthnFactor{
+				Id:         "webId",
+				FactorType: "web",
+			},
+			"token": OktaUserAuthnFactor{
+				Id:         "tokenId",
+				FactorType: "token",
+				Provider:   "SYMANTEC",
+			},
+			"token:software:totp": OktaUserAuthnFactor{
+				Id:         "token:software:totp:Id",
+				FactorType: "token:software:totp",
+			},
+			"token:hardware": OktaUserAuthnFactor{
+				Id:         "token:hardware:ID",
+				FactorType: "token:hardware",
+			},
+			"sms": OktaUserAuthnFactor{
+				Id:         "sms:ID",
+				FactorType: "sms",
+			},
+			"u2f": OktaUserAuthnFactor{
+				Id:         "u2f:ID",
+				FactorType: "u2f",
+			},
+			"OKTA push": OktaUserAuthnFactor{
+				Id:         "push:ID",
+				FactorType: "push",
+				Provider:   "OKTA",
+			},
+			"DUO push": OktaUserAuthnFactor{
+				Id:         "push:ID",
+				FactorType: "push",
+				Provider:   "DUO",
+			},
+		}
+
+		for factorType, authnFactor := range mfaIdTests {
+			id, err := GetFactorId(&authnFactor)
+			if assert.NoError(t, err, fmt.Sprintf("Failure for factorType: %s", factorType)) {
+				assert.Equal(t, authnFactor.Id, id, "confirm we get Id back")
+			}
+		}
+	})
+	t.Run("MFA Factor id lookup error cases", func(t *testing.T) {
+		mfaIdTests := map[string]OktaUserAuthnFactor{
+			"token": OktaUserAuthnFactor{
+				Id:         "tokenId",
+				FactorType: "token",
+				Provider:   "NOT SYMANTEC",
+			},
+			"push": OktaUserAuthnFactor{
+				Id:         "push:ID",
+				FactorType: "push",
+				Provider:   "not DUO or OKTA",
+			},
+		}
+
+		for factorType, authnFactor := range mfaIdTests {
+			_, err := GetFactorId(&authnFactor)
+			assert.Equal(t, err, fmt.Errorf("provider %s with factor %s not supported", authnFactor.Provider, authnFactor.FactorType), "confirm we get the correct error for "+factorType)
+		}
+		_, err := GetFactorId(&OktaUserAuthnFactor{FactorType: "not-supported"})
+		assert.Equal(t, err, fmt.Errorf("factor %s not supported", "not-supported"), "confirm we get the correct error")
+	})
+}

--- a/lib2/client/struct.go
+++ b/lib2/client/struct.go
@@ -1,0 +1,57 @@
+package client
+
+type SessionRequest struct {
+	SessionToken string `json:"sessionToken"`
+}
+type OktaUserAuthn struct {
+	StateToken   string                `json:"stateToken"`
+	SessionToken string                `json:"sessionToken"`
+	ExpiresAt    string                `json:"expiresAt"`
+	Status       string                `json:"status"`
+	Embedded     OktaUserAuthnEmbedded `json:"_embedded"`
+	FactorResult string                `json:"factorResult"`
+}
+type OktaStateToken struct {
+	StateToken string `json:"stateToken"`
+	PassCode   string `json:"passCode"`
+}
+
+type OktaUserAuthnEmbedded struct {
+	Factors []OktaUserAuthnFactor `json:"factors"`
+	Factor  OktaUserAuthnFactor   `json:"factor"`
+}
+type OktaUserAuthnFactor struct {
+	Id         string                      `json:"id"`
+	FactorType string                      `json:"factorType"`
+	Provider   string                      `json:"provider"`
+	Embedded   OktaUserAuthnFactorEmbedded `json:"_embedded"`
+	Profile    OktaUserAuthnFactorProfile  `json:"profile"`
+}
+type OktaUserAuthnFactorProfile struct {
+	CredentialId string `json:"credentialId"`
+	AppId        string `json:"appId"`
+	Version      string `json:"version"`
+}
+
+type OktaUserAuthnFactorEmbedded struct {
+	Verification OktaUserAuthnFactorEmbeddedVerification `json:"verification"`
+	Challenge    OktaUserAuthnFactorEmbeddedChallenge    `json:"challenge"`
+}
+type OktaUserAuthnFactorEmbeddedVerification struct {
+	Host         string                                       `json:"host"`
+	Signature    string                                       `json:"signature"`
+	FactorResult string                                       `json:"factorResult"`
+	Links        OktaUserAuthnFactorEmbeddedVerificationLinks `json:"_links"`
+}
+
+type OktaUserAuthnFactorEmbeddedChallenge struct {
+	Nonce           string `json:"nonce"`
+	TimeoutSeconnds int    `json:"timeoutSeconds"`
+}
+type OktaUserAuthnFactorEmbeddedVerificationLinks struct {
+	Complete OktaUserAuthnFactorEmbeddedVerificationLinksComplete `json:"complete"`
+}
+
+type OktaUserAuthnFactorEmbeddedVerificationLinksComplete struct {
+	Href string `json:"href"`
+}

--- a/lib2/provider/awssamlprovider.go
+++ b/lib2/provider/awssamlprovider.go
@@ -1,0 +1,450 @@
+// manages auth sessions for Okta applications
+package provider
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/segmentio/aws-okta/internal/sessioncache"
+	"github.com/segmentio/aws-okta/lib"
+
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	aws_session "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	log "github.com/sirupsen/logrus"
+	// use xerrors until 1.13 is stable/oldest supported version
+	"golang.org/x/xerrors"
+)
+
+const (
+	MaxSessionDuration    = time.Hour * 24 * 90
+	MinSessionDuration    = time.Minute * 15
+	MinAssumeRoleDuration = time.Minute * 15
+	MaxAssumeRoleDuration = time.Hour * 12
+
+	DefaultSessionDuration    = time.Hour * 4
+	DefaultAssumeRoleDuration = time.Minute * 15
+)
+
+type SessionCacheInterface interface {
+	Get(sessioncache.Key) (*sessioncache.Session, error)
+	Put(sessioncache.Key, *sessioncache.Session) error
+}
+
+type OktaClient interface {
+	AuthenticateUser() error
+	GetSessionToken() string
+	SaveSessionCookie() error
+	Request(method string, path string, queryParams url.Values, data []byte, format string, followRedirects bool) (*http.Response, error)
+	GetURL(string) (*url.URL, error)
+}
+
+type AwsSamlProvider struct {
+	credentials.Expiry
+	AwsSamlProviderOptions
+	oktaClient             OktaClient
+	keyring                keyring.Keyring
+	profileARN             string
+	oktaAwsSAMLUrl         string
+	oktaAccountName        string
+	awsRegion              string
+	profile                string
+	Expires                time.Time
+	sessions               SessionCacheInterface
+	defaultRoleSessionName string
+}
+
+type AwsSamlProviderOptions struct {
+	SessionDuration    time.Duration
+	AssumeRoleDuration time.Duration
+	ExpiryWindow       time.Duration
+	Profiles           lib.Profiles
+	AssumeRoleArn      string
+
+	// this option is deprecated.
+	// It will be ignored.
+	SessionCacheSingleItem bool
+}
+
+// validates aws saml configuration options.
+func (o *AwsSamlProviderOptions) Validate() error {
+	if o.SessionDuration < MinSessionDuration {
+		return errors.New("Minimum session duration is " + MinSessionDuration.String())
+	} else if o.SessionDuration > MaxSessionDuration {
+		return errors.New("Maximum session duration is " + MaxSessionDuration.String())
+	}
+	if o.AssumeRoleDuration < MinAssumeRoleDuration {
+		return errors.New("Minimum duration for assumed roles is " + MinAssumeRoleDuration.String())
+	} else if o.AssumeRoleDuration > MaxAssumeRoleDuration {
+		log.Println(o.AssumeRoleDuration)
+		return errors.New("Maximum duration for assumed roles is " + MaxAssumeRoleDuration.String())
+	}
+
+	return nil
+}
+
+// updates aws saml configuration with package provided defaults.
+func (o *AwsSamlProviderOptions) ApplyDefaults() {
+	if o.AssumeRoleDuration == 0 {
+		o.AssumeRoleDuration = DefaultAssumeRoleDuration
+	}
+	if o.SessionDuration == 0 {
+		o.SessionDuration = DefaultSessionDuration
+	}
+}
+
+// creates a new AWS saml provider
+func NewAwsSamlProvider(kr keyring.Keyring, profile string, opts AwsSamlProviderOptions, oktaClient OktaClient) (*AwsSamlProvider, error) {
+	var sessions SessionCacheInterface
+	var profileARN string
+	var ok bool
+	var err error
+
+	opts.ApplyDefaults()
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+
+	log.Debug("Provider Option is deprecated: SessionCacheSingleItem")
+	// Use single Kr Item session caching.
+	sessions = &sessioncache.SingleKrItemStore{kr}
+
+	source := lib.SourceProfile(profile, opts.Profiles)
+
+	// if the assumable role is passed it have it override what is in the profile
+	if opts.AssumeRoleArn != "" {
+		profileARN = opts.AssumeRoleArn
+		log.Debug("Overriding Assumable role with: ", profileARN)
+	} else {
+		profileARN, ok = opts.Profiles[source]["role_arn"]
+		if !ok {
+			return nil, errors.New("Source profile must provide `role_arn`")
+		}
+	}
+
+	provider := AwsSamlProvider{
+		AwsSamlProviderOptions: opts,
+		oktaClient:             oktaClient,
+		keyring:                kr,
+		profileARN:             profileARN,
+		sessions:               sessions,
+		profile:                profile,
+	}
+
+	if region := opts.Profiles[source]["region"]; region != "" {
+		provider.awsRegion = region
+	}
+	err = provider.getSamlURL()
+	if err != nil {
+		return nil, err
+	}
+	return &provider, nil
+}
+
+// Gets a set of STS credentials to access AWS services.
+func (p *AwsSamlProvider) Retrieve() (credentials.Value, error) {
+
+	window := p.ExpiryWindow
+	if window == 0 {
+		window = time.Minute * 5
+	}
+
+	// TODO(nick): why are we using the source profile name and not the actual profile's name?
+	source := lib.SourceProfile(p.profile, p.Profiles)
+	profileConf, ok := p.Profiles[p.profile]
+	if !ok {
+		return credentials.Value{}, fmt.Errorf("missing profile named %s", p.profile)
+	}
+	key := sessioncache.OrigKey{
+		ProfileName: source,
+		ProfileConf: profileConf,
+		Duration:    p.SessionDuration,
+	}
+
+	var creds sts.Credentials
+	if cachedSession, err := p.sessions.Get(key); err != nil {
+		creds, err = p.getSamlSessionCreds()
+		if err != nil {
+			return credentials.Value{}, xerrors.Errorf("getting creds via SAML: %w", err)
+		}
+		newSession := sessioncache.Session{
+			Name:        p.roleSessionName(),
+			Credentials: creds,
+		}
+		if err = p.sessions.Put(key, &newSession); err != nil {
+			return credentials.Value{}, xerrors.Errorf("putting to sessioncache", err)
+		}
+
+		// TODO(nick): not really clear why this is done
+		p.defaultRoleSessionName = newSession.Name
+	} else {
+		creds = cachedSession.Credentials
+		p.defaultRoleSessionName = cachedSession.Name
+	}
+
+	log.Debugf("Using session %s, expires in %s",
+		(*(creds.AccessKeyId))[len(*(creds.AccessKeyId))-4:],
+		creds.Expiration.Sub(time.Now()).String())
+
+	// If SourceProfile returns the same source then we do not need to assume a
+	// second role. Not assuming a second role allows us to assume IDP enabled
+	// roles directly.
+	if p.profile != source {
+		if role, ok := p.Profiles[p.profile]["role_arn"]; ok {
+			var err error
+			creds, err = p.assumeRoleFromSession(creds, role)
+			if err != nil {
+				return credentials.Value{}, err
+			}
+
+			log.Debugf("using role %s expires in %s",
+				(*(creds.AccessKeyId))[len(*(creds.AccessKeyId))-4:],
+				creds.Expiration.Sub(time.Now()).String())
+		}
+	}
+
+	p.SetExpiration(*(creds.Expiration), window)
+	p.Expires = *(creds.Expiration)
+
+	value := credentials.Value{
+		AccessKeyID:     *(creds.AccessKeyId),
+		SecretAccessKey: *(creds.SecretAccessKey),
+		SessionToken:    *(creds.SessionToken),
+		ProviderName:    "okta",
+	}
+
+	return value, nil
+}
+
+// GetRoleARN uses temporary credentials to call AWS's get-caller-identity and
+// returns the assumed role's ARN
+func (p *AwsSamlProvider) GetRoleARNWithRegion(creds credentials.Value) (string, error) {
+	config := aws.Config{Credentials: credentials.NewStaticCredentials(
+		creds.AccessKeyID,
+		creds.SecretAccessKey,
+		creds.SessionToken,
+	)}
+	if region := p.Profiles[lib.SourceProfile(p.profile, p.Profiles)]["region"]; region != "" {
+		config.WithRegion(region)
+	}
+	client := sts.New(aws_session.New(&config))
+
+	indentity, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		log.Errorf("Error getting caller identity: %s", err.Error())
+		return "", err
+	}
+	arn := *indentity.Arn
+	return arn, nil
+}
+
+// get the AWS saml url path from the AWS profile and store it in the provider
+// struct.
+//
+// uses the `aws_saml_url` to search for the url in the profile. If the url
+// doesn't exist in the profile an error is returned.
+func (p *AwsSamlProvider) getSamlURL() error {
+	oktaAwsSAMLUrl, profile, err := p.Profiles.GetValue(p.profile, "aws_saml_url")
+	if err != nil {
+		return errors.New("aws_saml_url missing from ~/.aws/config")
+	}
+	log.Debugf("Using aws_saml_url from profile %s: %s", profile, oktaAwsSAMLUrl)
+	p.oktaAwsSAMLUrl = oktaAwsSAMLUrl
+	return nil
+}
+
+// gets the Okta session cookie key from the profile or returns the default
+// value if the profile doesn't exist. The provider struct is not modified by
+// this method.
+func (p *AwsSamlProvider) getOktaSessionCookieKey() string {
+	oktaSessionCookieKey, profile, err := p.Profiles.GetValue(p.profile, "okta_session_cookie_key")
+	if err != nil {
+		return "okta-session-cookie"
+	}
+	log.Debugf("Using okta_session_cookie_key from profile: %s", profile)
+	return oktaSessionCookieKey
+}
+
+// get the Okta account name from the AWS profile and returns it to the caller.
+// if no account name is found in the profile the default value of `okta-creds`
+// is used.
+//
+// the provider struct is not modified by this method.
+func (p *AwsSamlProvider) getOktaAccountName() string {
+	oktaAccountName, profile, err := p.Profiles.GetValue(p.profile, "okta_account_name")
+	if err != nil {
+		return "okta-creds"
+	}
+	log.Debugf("Using okta_account_name: %s from profile: %s", oktaAccountName, profile)
+	return "okta-creds-" + oktaAccountName
+}
+
+// get a set of AWS STS credentials.
+func (p *AwsSamlProvider) getSamlSessionCreds() (sts.Credentials, error) {
+	log.Debugf("Using okta provider (%s)", p.oktaAccountName)
+	creds, err := p.authenticateProfileWithRegion(p.profileARN, p.SessionDuration, p.oktaAwsSAMLUrl, p.awsRegion)
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	//	p.defaultRoleSessionName = p.oktaClient.oktaCreds.Username
+
+	return creds, nil
+}
+
+// assumeRoleFromSession takes a session created with an okta SAML login and uses that to assume a role
+func (p *AwsSamlProvider) assumeRoleFromSession(creds sts.Credentials, roleArn string) (sts.Credentials, error) {
+	client := sts.New(aws_session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(
+		*creds.AccessKeyId,
+		*creds.SecretAccessKey,
+		*creds.SessionToken,
+	)}))
+
+	input := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String(p.roleSessionName()),
+		DurationSeconds: aws.Int64(int64(p.AssumeRoleDuration.Seconds())),
+	}
+
+	log.Debugf("Assuming role %s from session token", roleArn)
+	resp, err := client.AssumeRole(input)
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	return *resp.Credentials, nil
+}
+
+// roleSessionName returns the profile's `role_session_name` if set, or the
+// provider's defaultRoleSessionName if set. If neither is set, returns some
+// arbitrary unique string
+func (p *AwsSamlProvider) roleSessionName() string {
+	if name := p.Profiles[p.profile]["role_session_name"]; name != "" {
+		return name
+	}
+
+	if p.defaultRoleSessionName != "" {
+		return p.defaultRoleSessionName
+	}
+
+	// Try to work out a role name that will hopefully end up unique.
+	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+}
+
+// GetRoleARN makes a call to AWS to get-caller-identity and returns the
+// assumed role's name and ARN.
+func GetRoleARN(c credentials.Value) (string, error) {
+	client := sts.New(aws_session.New(&aws.Config{Credentials: credentials.NewStaticCredentialsFromCreds(c)}))
+
+	indentity, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		log.Errorf("Error getting caller identity: %s", err.Error())
+		return "", err
+	}
+	arn := *indentity.Arn
+	return arn, nil
+}
+
+// Authenticates the user with AWS, if the auth process is successful a valid
+// set of STS credentials are returned otherwise and error will be returned
+// containing a message to explain the error.
+func (p *AwsSamlProvider) authenticateProfileWithRegion(profileARN string, duration time.Duration, oktaAwsSAMLUrl string, region string) (sts.Credentials, error) {
+
+	var assertion SAMLAssertion
+	queryParams := url.Values{}
+
+	// Attempt to reuse session cookie
+	err := p.getAwsSAML(oktaAwsSAMLUrl, queryParams, nil, &assertion, "saml")
+	if err != nil {
+		log.Debug("Failed to reuse session token, starting flow from start")
+
+		if err := p.oktaClient.AuthenticateUser(); err != nil {
+			return sts.Credentials{}, err
+		}
+
+		queryParams.Set("onetimetoken", p.oktaClient.GetSessionToken())
+		if err = p.getAwsSAML(oktaAwsSAMLUrl, queryParams, nil, &assertion, "saml"); err != nil {
+			return sts.Credentials{}, err
+		}
+	}
+
+	principal, role, err := GetRoleFromSAML(assertion.Resp, profileARN)
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	var samlSess *session.Session
+	if region != "" {
+		log.Debugf("Using region: %s\n", region)
+		conf := &aws.Config{
+			Region: aws.String(region),
+		}
+		samlSess = session.Must(session.NewSession(conf))
+	} else {
+		samlSess = session.Must(session.NewSession())
+	}
+	svc := sts.New(samlSess)
+
+	samlParams := &sts.AssumeRoleWithSAMLInput{
+		PrincipalArn:    aws.String(principal),
+		RoleArn:         aws.String(role),
+		SAMLAssertion:   aws.String(string(assertion.RawData)),
+		DurationSeconds: aws.Int64(int64(duration.Seconds())),
+	}
+
+	samlResp, err := svc.AssumeRoleWithSAML(samlParams)
+	if err != nil {
+		log.WithField("role", role).Errorf(
+			"error assuming role with SAML: %s", err.Error())
+		return sts.Credentials{}, err
+	}
+
+	err = p.oktaClient.SaveSessionCookie()
+	return *samlResp.Credentials, err
+}
+
+// Gets the AWS SAML assertion from OKTA.
+//
+// this includes parsing the HTML returned by Okta to retrieve the encoded SAML
+// assertion passed via a hidden HTML element.
+func (p *AwsSamlProvider) getAwsSAML(path string, queryParams url.Values, data []byte, recv interface{}, format string) (err error) {
+	res, err := p.oktaClient.Request("GET", path, queryParams, data, format, true)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("%s %v: %s", "GET", res.Request.URL, res.Status)
+	} else if recv != nil {
+		switch format {
+		case "json":
+			err = json.NewDecoder(res.Body).Decode(recv)
+		default:
+			var rawData []byte
+			rawData, err = ioutil.ReadAll(res.Body)
+			if err != nil {
+				return
+			}
+			if err := ParseSAML(rawData, recv.(*SAMLAssertion)); err != nil {
+				log.Debug("SAML parsing failed: ", err)
+				return fmt.Errorf("Okta user does not have the AWS app added to their account.  Please contact your Okta admin to make sure things are configured properly.")
+			}
+		}
+	}
+
+	return
+}
+
+// get the full Okta SAML login url, including domain.
+func (p *AwsSamlProvider) GetSAMLLoginURL() (*url.URL, error) {
+	return p.oktaClient.GetURL(p.oktaAwsSAMLUrl)
+}

--- a/lib2/provider/awssamlprovider_test.go
+++ b/lib2/provider/awssamlprovider_test.go
@@ -1,0 +1,339 @@
+package provider
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/99designs/keyring"
+	"github.com/stretchr/testify/assert"
+	gock "gopkg.in/h2non/gock.v1"
+	"testing"
+)
+
+type testOktaClient struct {
+	client  http.Client
+	baseURL string
+}
+
+func (c testOktaClient) AuthenticateUser() error {
+	return nil
+}
+func (c testOktaClient) GetSessionToken() string {
+	return "my-fake-session-token"
+}
+func (c testOktaClient) SaveSessionCookie() error {
+	return nil
+}
+func (c testOktaClient) Request(method string, path string, queryParams url.Values, data []byte, format string, followRedirects bool) (*http.Response, error) {
+
+	requestUrl, err := url.Parse(fmt.Sprintf(
+		"%s/%s", c.baseURL, path,
+	))
+
+	requestUrl.RawQuery = queryParams.Encode()
+	if err != nil {
+		return nil, err
+	}
+	req := &http.Request{
+		Method:        method,
+		URL:           requestUrl,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          ioutil.NopCloser(bytes.NewReader(data)),
+		ContentLength: int64(len(data)),
+	}
+	res, err := c.client.Do(req)
+	return res, err
+}
+func (c testOktaClient) GetURL(path string) (*url.URL, error) {
+	requestUrl, err := url.Parse(fmt.Sprintf(
+		"%s/%s", c.baseURL, path,
+	))
+	if err != nil {
+		return nil, err
+	}
+	return requestUrl, nil
+}
+
+func TestAwsSamlProvider(t *testing.T) {
+	defer gock.Off()
+	var (
+		oktaClient      testOktaClient
+		err             error
+		profile         string
+		Kr              keyring.Keyring
+		KrBackend       []keyring.BackendType
+		awsSamlProvider *AwsSamlProvider
+	)
+	//
+	// start setup
+	//
+
+	// uncomment this to get gock to dump all requests
+	//	gock.Observe(gock.DumpRequest)
+
+	profile = "okta-test-profile"
+	// we use a file backend for testing in a temp dir
+	KrBackend = append(KrBackend, keyring.FileBackend)
+
+	tempDir, err := ioutil.TempDir("", "aws-okta")
+	assert.NoError(t, err, "create a temp dir to back the keyring")
+	Kr, err = keyring.Open(keyring.Config{
+		AllowedBackends:          KrBackend,
+		KeychainTrustApplication: true,
+		ServiceName:              "aws-okta-login",
+		LibSecretCollectionName:  "awsvault",
+		FileDir:                  tempDir,
+		FilePasswordFunc:         func(string) (string, error) { return "funkypass", nil }})
+	assert.NoError(t, err, "No errors when opening a keyring")
+	providerOptions := AwsSamlProviderOptions{
+		Profiles: map[string]map[string]string{
+			profile: map[string]string{
+				"role_arn":     "arn:aws:iam::000000000000:role/sharks.are.friends.samlrole",
+				"aws_saml_url": "/a/saml/url",
+			},
+		},
+	}
+	oktaClient = testOktaClient{
+		client:  http.Client{},
+		baseURL: "https://canada",
+	}
+	awsSamlProvider, err = NewAwsSamlProvider(Kr, profile, providerOptions, oktaClient)
+
+	// intercept the http client with gock to mock out the Okta responses
+	//gock.InterceptClient(&(awsSamlProvider.oktaClient.Client))
+
+	//
+	// end setup
+	//
+
+	t.Run("create the provider", func(t *testing.T) {
+
+		assert.Equal(t,
+			profile,
+			awsSamlProvider.profile,
+			"the profile is set correctly")
+		assert.Equal(t,
+			providerOptions.Profiles[profile]["role_arn"],
+			awsSamlProvider.profileARN,
+			"the profile arn is set correctly")
+		assert.Equal(t, profile, awsSamlProvider.profile, "the profile is set correctly")
+		assert.Equal(t, time.Duration(0), awsSamlProvider.ExpiryWindow, "Expiry Window is set correctly")
+		assert.NotNil(t, awsSamlProvider.oktaClient, "confirm okta client creation")
+
+	})
+	t.Run("test parsing saml assertion", func(t *testing.T) {
+		var samlAssertion SAMLAssertion
+		//var expectedSamlAssertion SAMLAssertion
+		var rawData []byte
+		rawData, err = ioutil.ReadFile("test-resources/saml-test-data.html")
+		assert.NoError(t, err, "able to read saml assertion data")
+
+		err = ParseSAML(rawData, &samlAssertion)
+		if assert.NoError(t, err, "able to parse saml assertion without errors") {
+			assert.Equal(t, "", samlAssertion.Resp.SAMLP, "parsing samlp")
+			assert.Equal(t, "", samlAssertion.Resp.SAML, "parsing saml")
+			assert.Equal(t, "", samlAssertion.Resp.SAMLSIG, "parsing samlsig")
+			assert.Equal(t, "http://localhost:8888/simplesamlphp/www/module.php/saml/sp/saml2-acs.php/example-okta-com", samlAssertion.Resp.Destination, "parsing destination")
+		}
+	})
+	t.Run("provider helpers with default values", func(t *testing.T) {
+		cookieKey := awsSamlProvider.getOktaSessionCookieKey()
+		assert.Equal(t, "okta-session-cookie", cookieKey, "correct cookie key")
+		accountName := awsSamlProvider.getOktaAccountName()
+		assert.Equal(t, "okta-creds", accountName, "correct cookie key")
+
+		loginURL, err := awsSamlProvider.GetSAMLLoginURL()
+		if assert.NoError(t, err, "failed to get saml login url") {
+			assert.Equal(t, "https://canada//a/saml/url", loginURL.String(), "able to get the saml login url")
+		}
+	})
+	t.Run("test get call to aws app", func(t *testing.T) {
+		gock.New("https://canada").
+			Get("/a/saml/url").
+			MatchParam("onetimetoken", "testing-token").
+			Reply(200).
+			File("test-resources/saml-test-data.html")
+		queryParams := url.Values{}
+		var samlAssertion SAMLAssertion
+
+		queryParams.Set("onetimetoken", "testing-token")
+		err = awsSamlProvider.getAwsSAML("/a/saml/url", queryParams, nil, &samlAssertion, "saml")
+		if assert.NoError(t, err, "no errors when parsing saml assertion") {
+			assert.Equal(t, "", samlAssertion.Resp.SAMLP, "parsing samlp")
+			assert.Equal(t, "", samlAssertion.Resp.SAML, "parsing saml")
+			assert.Equal(t, "", samlAssertion.Resp.SAMLSIG, "parsing samlsig")
+			assert.Equal(t, "http://localhost:8888/simplesamlphp/www/module.php/saml/sp/saml2-acs.php/example-okta-com", samlAssertion.Resp.Destination, "parsing destination")
+		}
+	})
+	t.Run("retrieve a token", func(t *testing.T) {
+		gock.New("https://canada").
+			Get("/a/saml/url").
+			MatchParam("onetimetoken", "my-fake-session-token").
+			Reply(200).
+			File("test-resources/saml-test-data.html")
+
+		gock.New("https://sts.amazonaws.com").
+			Post("/").
+			Reply(200).
+			BodyString(`<AssumeRoleWithSAML xmlns="https://sts.amazonaws.com.cn/doc/2011-06-15/">
+<AssumeRoleWithSAMLResult>
+<Credentials>
+  <SessionToken>AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE</SessionToken>
+  <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+  <Expiration>2011-07-11T19:55:29.611Z</Expiration>
+  <AccessKeyId>AKIAIOSFODNN7EXAMPLE</AccessKeyId>
+</Credentials>
+</GetSessionTokenResult>
+<ResponseMetadata>
+<RequestId>58c5dbae-abef-11e0-8cfe-09039844ac7d</RequestId>
+</ResponseMetadata>
+</AssumeRoleWithSAMLResultResponse>`)
+		stsCreds, err := awsSamlProvider.Retrieve()
+		if assert.NoError(t, err, "Can retrieve without an error") {
+			assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", stsCreds.AccessKeyID, "Check the sts credentials are set")
+			assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY", stsCreds.SecretAccessKey, "Check the sts credentials are set")
+			assert.Equal(t, "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE", stsCreds.SessionToken, "Check the sts credentials are set")
+			assert.Equal(t, "okta", stsCreds.ProviderName, "Check the sts credentials are set")
+		}
+
+		gock.New("https://sts.amazonaws.com").
+			Post("/").
+			Reply(200).
+			BodyString(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+   <Arn>arn:aws:iam::000000000000:role/sharks.are.friends.samlrole</Arn>
+    <UserId>AIDACKCEVSQ6C2EXAMPLE</UserId>
+    <Account>123456789012</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata>
+    <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+  </ResponseMetadata>
+</GetCallerIdentityResponse>`)
+		roleArn, err := awsSamlProvider.GetRoleARNWithRegion(stsCreds)
+		if assert.NoError(t, err, "Can retrieve without an error") {
+			assert.Equal(t, providerOptions.Profiles[profile]["role_arn"], roleArn, "Confirm the role arn")
+		}
+		gock.New("https://sts.amazonaws.com").
+			Post("/").
+			Reply(200).
+			BodyString(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+   <Arn>arn:aws:iam::000000000000:role/sharks.are.friends.samlrole</Arn>
+    <UserId>AIDACKCEVSQ6C2EXAMPLE</UserId>
+    <Account>123456789012</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata>
+    <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+  </ResponseMetadata>
+</GetCallerIdentityResponse>`)
+		roleArn, err = GetRoleARN(stsCreds)
+		if assert.NoError(t, err, "Can retrieve without an error") {
+			assert.Equal(t, providerOptions.Profiles[profile]["role_arn"], roleArn, "Confirm the role arn")
+		}
+	})
+}
+
+func TestAwsSamlProviderUtils(t *testing.T) {
+	var (
+		err error
+	)
+	//
+	// start setup
+	//
+
+	//
+	// end setup
+	//
+
+	t.Run("provider options success", func(t *testing.T) {
+		providerOptions := AwsSamlProviderOptions{}
+		providerOptions.ApplyDefaults()
+		err = providerOptions.Validate()
+		if assert.NoError(t, err, "Got a provider options validation error") {
+			assert.Equal(t, DefaultAssumeRoleDuration, providerOptions.AssumeRoleDuration)
+			assert.Equal(t, DefaultSessionDuration, providerOptions.SessionDuration)
+		}
+	})
+
+	t.Run("provider options errors", func(t *testing.T) {
+		optionErrorTests := map[string]AwsSamlProviderOptions{
+			"SessionDuration too short error": AwsSamlProviderOptions{
+				SessionDuration: time.Second * 10,
+			},
+			"SessionDuration too long error": AwsSamlProviderOptions{
+				SessionDuration: time.Hour * 9000,
+			},
+			"AssumeRoleDuration too short error": AwsSamlProviderOptions{
+				SessionDuration:    time.Minute * 45,
+				AssumeRoleDuration: time.Second * 30,
+			},
+			"AssumeRoleDuration too long error": AwsSamlProviderOptions{
+				SessionDuration:    time.Minute * 45,
+				AssumeRoleDuration: time.Hour * 9000,
+			},
+		}
+		for test, opts := range optionErrorTests {
+			err = opts.Validate()
+			assert.Error(t, err, "Correctly Failing validation. Case: "+test)
+		}
+	})
+}
+
+func TestAwsSamlProviderCreateErrors(t *testing.T) {
+
+	var (
+		err       error
+		profile   string
+		Kr        keyring.Keyring
+		KrBackend []keyring.BackendType
+	)
+	//
+	// start setup
+	//
+
+	// uncomment this to get gock to dump all requests
+	//	gock.Observe(gock.DumpRequest)
+
+	profile = "okta-test-profile"
+	// we use a file backend for testing in a temp dir
+	KrBackend = append(KrBackend, keyring.FileBackend)
+
+	tempDir, err := ioutil.TempDir("", "aws-okta")
+	assert.NoError(t, err, "create a temp dir to back the keyring")
+	Kr, err = keyring.Open(keyring.Config{
+		AllowedBackends:          KrBackend,
+		KeychainTrustApplication: true,
+		ServiceName:              "aws-okta-login",
+		LibSecretCollectionName:  "awsvault",
+		FileDir:                  tempDir,
+		FilePasswordFunc:         func(string) (string, error) { return "funkypass", nil }})
+	assert.NoError(t, err, "No errors when opening a keyring")
+
+	//
+	// end setup
+	//
+	t.Run("create with invalid opts", func(t *testing.T) {
+
+		_, err := NewAwsSamlProvider(Kr, profile, AwsSamlProviderOptions{SessionDuration: time.Second * 3}, testOktaClient{})
+		assert.Equal(t, fmt.Errorf("Minimum session duration is 15m0s"), err)
+
+	})
+	t.Run("create with missing profile arn", func(t *testing.T) {
+
+		_, err := NewAwsSamlProvider(Kr, profile, AwsSamlProviderOptions{}, testOktaClient{})
+		assert.Equal(t, fmt.Errorf("Source profile must provide `role_arn`"), err)
+
+	})
+	t.Run("create with assume role arn, okta-creds, no saml url", func(t *testing.T) {
+
+		_, err = NewAwsSamlProvider(Kr, profile, AwsSamlProviderOptions{AssumeRoleArn: "some fake arn"}, testOktaClient{})
+		assert.Equal(t, fmt.Errorf("aws_saml_url missing from ~/.aws/config"), err)
+
+	})
+}

--- a/lib2/provider/saml-struct.go
+++ b/lib2/provider/saml-struct.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"encoding/xml"
+)
+
+type AssumableRole struct {
+	Role      string
+	Principal string
+}
+
+type SAMLAssertion struct {
+	Resp    *Response
+	RawData []byte
+}
+
+type AssumableRoles []AssumableRole
+
+type Response struct {
+	XMLName      xml.Name
+	SAMLP        string `xml:"xmlns:saml2p,attr"`
+	SAML         string `xml:"xmlns:saml2,attr"`
+	SAMLSIG      string `xml:"xmlns:saml2sig,attr"`
+	Destination  string `xml:"Destination,attr"`
+	ID           string `xml:"ID,attr"`
+	Version      string `xml:"Version,attr"`
+	IssueInstant string `xml:"IssueInstant,attr"`
+	InResponseTo string `xml:"InResponseTo,attr"`
+
+	Assertion Assertion `xml:"Assertion"`
+	Status    Status    `xml:"Status"`
+
+	originalString string
+}
+
+type Assertion struct {
+	XMLName            xml.Name
+	ID                 string `xml:"ID,attr"`
+	Version            string `xml:"Version,attr"`
+	XS                 string `xml:"xmlns:xs,attr"`
+	XSI                string `xml:"xmlns:xsi,attr"`
+	SAML               string `xml:"saml,attr"`
+	IssueInstant       string `xml:"IssueInstant,attr"`
+	Subject            Subject
+	Conditions         Conditions
+	AttributeStatement AttributeStatement
+}
+
+type Conditions struct {
+	XMLName      xml.Name
+	NotBefore    string `xml:",attr"`
+	NotOnOrAfter string `xml:",attr"`
+}
+
+type Subject struct {
+	XMLName             xml.Name
+	NameID              NameID
+	SubjectConfirmation SubjectConfirmation
+}
+
+type SubjectConfirmation struct {
+	XMLName                 xml.Name
+	Method                  string `xml:",attr"`
+	SubjectConfirmationData SubjectConfirmationData
+}
+
+type Status struct {
+	XMLName    xml.Name
+	StatusCode StatusCode `xml:"StatusCode"`
+}
+
+type SubjectConfirmationData struct {
+	InResponseTo string `xml:",attr"`
+	NotOnOrAfter string `xml:",attr"`
+	Recipient    string `xml:",attr"`
+}
+
+type NameID struct {
+	XMLName xml.Name
+	Format  string `xml:",attr"`
+	Value   string `xml:",innerxml"`
+}
+
+type StatusCode struct {
+	XMLName xml.Name
+	Value   string `xml:",attr"`
+}
+
+type AttributeValue struct {
+	XMLName xml.Name
+	Type    string `xml:"xsi:type,attr"`
+	Value   string `xml:",innerxml"`
+}
+
+type Attribute struct {
+	XMLName         xml.Name
+	Name            string           `xml:",attr"`
+	FriendlyName    string           `xml:",attr"`
+	NameFormat      string           `xml:",attr"`
+	AttributeValues []AttributeValue `xml:"AttributeValue"`
+}
+
+type AttributeStatement struct {
+	XMLName    xml.Name
+	Attributes []Attribute `xml:"Attribute"`
+}

--- a/lib2/provider/saml.go
+++ b/lib2/provider/saml.go
@@ -1,0 +1,189 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/segmentio/aws-okta/lib"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/html"
+)
+
+var awsRoleARNRegex = regexp.MustCompile(`arn:[a-z-]+:iam::(\d{12}):role/(.*)`)
+
+func ParseSAML(body []byte, resp *SAMLAssertion) (err error) {
+	var val string
+	var data []byte
+	var doc *html.Node
+	doc, err = html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return
+	}
+
+	val, _ = GetNode(doc, "SAMLResponse")
+	if val != "" {
+		resp.RawData = []byte(val)
+		val = strings.Replace(val, "&#x2b;", "+", -1)
+		val = strings.Replace(val, "&#x3d;", "=", -1)
+		data, err = base64.StdEncoding.DecodeString(val)
+		if err != nil {
+			return
+		}
+	}
+
+	err = xml.Unmarshal(data, &resp.Resp)
+	return
+}
+func GetNode(n *html.Node, name string) (val string, node *html.Node) {
+	var isMatch bool
+	if n.Type == html.ElementNode && n.Data == "input" {
+		for _, a := range n.Attr {
+			if a.Key == "name" && a.Val == name {
+				isMatch = true
+			}
+			if a.Key == "value" && isMatch {
+				val = a.Val
+			}
+		}
+	}
+	if node == nil || val == "" {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			val, node = GetNode(c, name)
+			if val != "" {
+				return
+			}
+		}
+	}
+	return
+}
+func GetRoleFromSAML(resp *Response, profileARN string) (string, string, error) {
+
+	roles, err := GetAssumableRolesFromSAML(resp)
+	if err != nil {
+		return "", "", err
+	}
+	role, err := GetRole(roles, profileARN)
+	if err != nil {
+		return "", "", err
+	}
+	return role.Principal, role.Role, nil
+}
+
+func GetAssumableRolesFromSAML(resp *Response) (AssumableRoles, error) {
+	roleList := []AssumableRole{}
+
+	for _, a := range resp.Assertion.AttributeStatement.Attributes {
+		if strings.HasSuffix(a.Name, "SAML/Attributes/Role") {
+			for _, v := range a.AttributeValues {
+				log.Debugf("Got SAML role attribute: %s", v.Value)
+				tokens := strings.Split(v.Value, ",")
+				if len(tokens) != 2 {
+					continue
+				}
+
+				// Amazon's documentation suggests that the
+				// Role ARN should appear first in the comma-delimited
+				// set in the Role Attribute that SAML IdP returns.
+				//
+				// See the section titled "An Attribute element with the Name attribute set
+				// to https://aws.amazon.com/SAML/Attributes/Role" on this page:
+				// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html
+				//
+				// In practice, though, Okta SAML integrations with AWS will succeed
+				// with either the role or principal ARN first, and these `if` statements
+				// allow that behavior in this program.
+				if strings.Contains(tokens[0], ":saml-provider/") {
+					// if true, Role attribute is formatted like:
+					// arn:aws:iam::ACCOUNT:saml-provider/provider,arn:aws:iam::account:role/roleName
+					roleList = append(roleList, AssumableRole{Role: tokens[1],
+						Principal: tokens[0]})
+				} else if strings.Contains(tokens[1], ":saml-provider/") {
+					// if true, Role attribute is formatted like:
+					// arn:aws:iam::account:role/roleName,arn:aws:iam::ACCOUNT:saml-provider/provider
+					roleList = append(roleList, AssumableRole{Role: tokens[0],
+						Principal: tokens[1]})
+				} else {
+					return AssumableRoles{}, fmt.Errorf("Unable to get roles from %s", v.Value)
+				}
+
+			}
+		}
+	}
+	return roleList, nil
+}
+
+func GetRole(roleList AssumableRoles, profileARN string) (AssumableRole, error) {
+
+	// if the user doesn't have any roles they can assume return an error.
+	if len(roleList) == 0 {
+		return AssumableRole{}, fmt.Errorf("There are no roles that can be assumed")
+	}
+
+	// A role arn was provided as part of the profile, we will assume that role.
+	if profileARN != "" {
+		for _, arole := range roleList {
+			if profileARN == arole.Role {
+				return arole, nil
+			}
+		}
+		return AssumableRole{}, fmt.Errorf("ARN isn't valid")
+	}
+
+	// if the user only has one role assume that role without prompting.
+	if len(roleList) == 1 {
+		return roleList[0], nil
+	}
+
+	// Sort the roles in alphabetical order
+	sort.Slice(roleList, func(i, j int) bool {
+		return roleList[i].Role < roleList[j].Role
+	})
+
+	var roleName, previousAccountID, currentAccountID string
+
+	for i, arole := range roleList {
+		currentAccountID, roleName = accountIDAndRoleFromRoleARN(arole.Role)
+		if currentAccountID != previousAccountID {
+			fmt.Printf("\nAccount: %s\n", currentAccountID)
+		}
+		previousAccountID = currentAccountID
+
+		fmt.Printf("%4d - %s\n", i, roleName)
+	}
+	fmt.Println("")
+
+	i, err := lib.Prompt("Select Role to Assume", false)
+	if err != nil {
+		return AssumableRole{}, err
+	}
+	if i == "" {
+		return AssumableRole{}, errors.New("Invalid selection - Please use an option that is listed")
+	}
+	factorIdx, err := strconv.Atoi(i)
+	if err != nil {
+		return AssumableRole{}, err
+	}
+	if factorIdx > (len(roleList) - 1) {
+		return AssumableRole{}, errors.New("Invalid selection - Please use an option that is listed")
+	}
+	return roleList[factorIdx], nil
+}
+func accountIDAndRoleFromRoleARN(roleARN string) (string, string) {
+	matches := awsRoleARNRegex.FindStringSubmatch(roleARN)
+
+	// matches will contain ("roleARN", "accountID", "roleName")
+	if len(matches) == 3 {
+		return matches[1], matches[2]
+	}
+
+	// Getting here means we failed to extract accountID and roleName from
+	// roleARN. It should "not" happen, but if it does, return empty string
+	// as accountID and roleARN as roleName instead.
+	return "", roleARN
+}

--- a/lib2/provider/test-resources/saml-assertion.xml
+++ b/lib2/provider/test-resources/saml-assertion.xml
@@ -1,0 +1,142 @@
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 Destination="http://localhost:8888/simplesamlphp/www/module.php/saml/sp/saml2-acs.php/example-okta-com"
+                 ID="id304067580046365441472203853"
+                 InResponseTo="_2b16caecb21804d0271c7b45734978a31b122c0b9a"
+                 IssueInstant="2017-02-02T03:13:05.114Z"
+                 Version="2.0"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 >
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                  Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+                  >http://www.orgname.okta.com</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+            <ds:Reference URI="#id304067580045365441472303853">
+                <ds:Transforms>
+                    <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                    <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                        <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"
+                                                PrefixList="xs"
+                                                />
+                    </ds:Transform>
+                </ds:Transforms>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+                <ds:DigestValue>hF6r9lkeTRvgbJA/0bc8ykvCqES8rUzuW9YYShmlQvo=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>I82goYxTr5q2D+eWvj6O+DnqOG/xtAStirrgTY1dpBQ2plrI6e4t1g6stXZ47+y3qX81xSPv2pcVXp6NlhxU2twBK+1xL2tduymVrwWWI4VATdx5SjmcYaH5FKaDn1ee6Vs7YtYDZJzJDqGe/+5SaemnstrVmXbjmKwDinO5ttvNsW8R1LBF+Zxr8ti+2Jkggn9PRoYp+J/MZ5+sMZgky2HB70u0vrwiL+4ELD/avj8FeeHBMJwqllWQ1qCZ5ELtRLXANCNge3Ur392HkGy4HB2t1EVcMAO8wZpAzHMnp6IozQM8+/2aPdDTapnv4kOj8scxsoZlbMHAZCgfl3lj7w==</ds:SignatureValue>
+        <ds:KeyInfo>
+            <ds:X509Data>
+                <ds:X509Certificate>MIIDpDCCAoygAwIBAgIGAVVfq86GMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldnN1cHBvcnQxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMTYwNjE3MTg0MTIyWhcNMjYwNjE3MTg0MjIyWjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXZzdXBwb3J0MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+qp10VJvKjqIEk30bv0WPw6XhZtTm19XfLrwyHRG1aYQshkcIolS9Vvp5SdL6dDEctdf5dznrQTlr
+8Q+LUIC6JGnVzA/qgC1UpsXYdfaod0c35GM8HDsHni0MNUnHt/2MqDW6PkYoIdjniDp21wOCiORE
+FGuC1kUQQJY2yQ8bQJVEKCEyIUPGXLMcQlbB0vAkbGeqz4HCZBX/n7wr/50MMQz8YOLSkx/0Ojls
+sGEA6KAbdFutrvSUKIUeZc4XFfySm9KJ1Vi83PpacOfWuKyktjPR0mC6wK87PuN32boa4nQ2+BMf
+v/qgx4e5RDnTYk2+iPcwN6nKxJfS66kKhpfMdwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA8R607
+iL9Sx9QKo31zG2xG24drYxaWta6G5XKcROkFk2ZVfRAhS9rx1WFXuCV5e/ys0z7jILWKisTkjegY
+uubqy6awBbjDRxnUct0OdZU4siHWYjvL+SYOT2Pk8IwlD4HGNsee6WmURvfpL2Yib9Xc85qVp1W9
+t7GU2GZVnOyU7a/JfAgDw79z5dH1BQsCW+nvgeO5VgFXVOSf7dBOB2PlwG5DlH5MgNa67eH3Wr9B
+RKvwyyTfqfq9pgSmB9xNVJIeVZbbZGTlNGqJti24E0AiIPggtxg5NJ+HHnEQ5RxdSsR4fbMz9i0K
+/bXt6hPgGu7xYRSv1RfvKcR1NjYk3nnD</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+    </ds:Signature>
+    <saml2p:Status xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                     ID="id304067580046759701759203951"
+                     IssueInstant="2017-02-02T03:13:05.114Z"
+                     Version="2.0"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     >
+        <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+                      xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                      >http://www.orgname.okta.com</saml2:Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo>
+                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+                <ds:Reference URI="#id304067580046759701759203951">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"
+                                                    PrefixList="xs"
+                                                    />
+                        </ds:Transform>
+                    </ds:Transforms>
+                    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+                    <ds:DigestValue>S8mNiYKRl/EwtRMUnwqL8oLfaBNHpgf1Kl1fVmHboX4=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>ipdSi9HVuHisncXx5xOxTTdyV0i1yMRecpTWVq5HF8Tunc6GImyAd7c7bLGIxRVrqWaL49+eKzs/G906ekWd3/2O7MMXvXb3p9SnQF74mV90p+l+Pb3CnuPuithbF2dBgzUe+AadZs8ZrgfTnC+s7zx/ZKsjfK4JbUNC7zajXl0+PcoJUic3NVe5Gkda/+caKAVkIc7JvT6pkp3gEQhMowfb5YtsgO41HNYu92RmJCikPEGawgsc4PKzvrMUSZZa52XYrTTRgpt6RvYA2PRBuocExRS3M1oLpEgKrmJ9oCzESaMHuqulQbY8lRfZnehjl+tzg92W8YNkrR4qPaLlYA==</ds:SignatureValue>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIDpDCCAoygAwIBAgIGAVVfq86GMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldnN1cHBvcnQxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMTYwNjE3MTg0MTIyWhcNMjYwNjE3MTg0MjIyWjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXZzdXBwb3J0MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+qp10VJvKjqIEk30bv0WPw6XhZtTm19XfLrwyHRG1aYQshkcIolS9Vvp5SdL6dDEctdf5dznrQTlr
+8Q+LUIC6JGnVzA/qgC1UpsXYdfaod0c35GM8HDsHni0MNUnHt/2MqDW6PkYoIdjniDp21wOCiORE
+FGuC1kUQQJY2yQ8bQJVEKCEyIUPGXLMcQlbB0vAkbGeqz4HCZBX/n7wr/50MMQz8YOLSkx/0Ojls
+sGEA6KAbdFutrvSUKIUeZc4XFfySm9KJ1Vi83PpacOfWuKyktjPR0mC6wK87PuN32boa4nQ2+BMf
+v/qgx4e5RDnTYk2+iPcwN6nKxJfS66kKhpfMdwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA8R607
+iL9Sx9QKo31zG2xG24drYxaWta6G5XKcROkFk2ZVfRAhS9rx1WFXuCV5e/ys0z7jILWKisTkjegY
+uubqy6awBbjDRxnUct0OdZU4siHWYjvL+SYOT2Pk8IwlD4HGNsee6WmURvfpL2Yib9Xc85qVp1W9
+t7GU2GZVnOyU7a/JfAgDw79z5dH1BQsCW+nvgeO5VgFXVOSf7dBOB2PlwG5DlH5MgNa67eH3Wr9B
+RKvwyyTfqfq9pgSmB9xNVJIeVZbbZGTlNGqJti24E0AiIPggtxg5NJ+HHnEQ5RxdSsR4fbMz9i0K
+/bXt6hPgGu7xYRSv1RfvKcR1NjYk3nnD</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </ds:Signature>
+        <saml2:Subject xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">userName</saml2:NameID>
+            <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml2:SubjectConfirmationData InResponseTo="_2b16caecb21804d0271c7b45734978a31b122c0b9a"
+                                               NotOnOrAfter="2017-02-02T03:18:05.114Z"
+                                               Recipient="http://localhost:8888/simplesamlphp/www/module.php/saml/sp/saml2-acs.php/example-okta-com"
+                                               />
+            </saml2:SubjectConfirmation>
+        </saml2:Subject>
+        <saml2:Conditions NotBefore="2017-02-02T03:08:05.114Z"
+                          NotOnOrAfter="2017-02-02T03:18:05.114Z"
+                          xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                          >
+            <saml2:AudienceRestriction>
+                <saml2:Audience>http://localhost:8888/simplesamlphp/www/module.php/saml/sp/metadata.php/example-okta-com</saml2:Audience>
+            </saml2:AudienceRestriction>
+        </saml2:Conditions>
+        <saml2:AuthnStatement AuthnInstant="2017-02-02T03:13:05.114Z"
+                              SessionIndex="_2b16caecb21804d0271c7b45734978a31b122c0b9a"
+                              xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                              >
+            <saml2:AuthnContext>
+                <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+            </saml2:AuthnContext>
+        </saml2:AuthnStatement>
+        <saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+<saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                      xsi:type="xs:string"
+                                      >arn:aws:iam::000000000000:saml-provider/OKTA,arn:aws:iam::000000000000:role/clowns.are.scary.samlrole</saml2:AttributeValue>
+                <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                      xsi:type="xs:string"
+                                      >arn:aws:iam::000000000000:role/sharks.are.friends.samlrole,arn:aws:iam::000000000000:saml-provider/OKTA</saml2:AttributeValue>
+            </saml2:Attribute>
+        </saml2:AttributeStatement>
+    </saml2:Assertion>
+</saml2p:Response>

--- a/lib2/provider/test-resources/saml-test-data.html
+++ b/lib2/provider/test-resources/saml-test-data.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html><html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><meta name="robots" content="noarchive"/><meta name="googlebot" content="noarchive"/><meta name="robots" content="noindex" />
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+<meta name="apple-mobile-web-app-capable" content="yes"><meta name="googlebot" content="noindex" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="none" />
+
+<link href="https://ok6static.oktacdn.com/assets/img/icons/favicons/favicon-16x16.c55b69ae49b08edc7c000d12b8e5483f.png" rel="icon" type="image/png" sizes="16x16"/><link href="https://ok6static.oktacdn.com/assets/img/icons/favicons/favicon-32x32.99bc356b6e293b927f9e3a2b69761c26.png" rel="icon" type="image/png" sizes="32x32"/><link href="https://ok6static.oktacdn.com/assets/img/icons/favicons/favicon-96x96.de98828614fa33ca04fcfaa07679f345.png" rel="icon" type="image/png" sizes="96x96"/><meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-TileImage" content="/img/icons/favicons/ms-icon-144x144.png">
+<meta name="application-name" content="Okta"/>
+<meta name="theme-color" content="#ffffff">
+<meta name="msapplication-config" content="/img/icons/favicons/browserconfig.xml"/>
+
+<title>
+    autonomic - Signing in...</title>
+<!--[if IE]><link href="https://ok6static.oktacdn.com/assets/css/ie/ie.67af4e98a9276b3eedc54211bb17ace8.css" type="text/css" rel="stylesheet"/><![endif]-->
+<!--[if gte IE 9]><link href="https://ok6static.oktacdn.com/assets/css/ie/ie9.e98bfbcf44b614a6d63c04328b8b7b5e.css" type="text/css" rel="stylesheet"/><![endif]-->
+
+<script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
+
+<script>
+    var okta = {
+        migrateMute: true,
+        locale: 'en',
+        debug: false,
+        deployEnv: 'PROD',
+        userId: '00u1rzvi3qmEzO8zS2p7',
+        settings: {
+            orgId: '00o1qcafl7V5Z92UC2p7',
+            orgName: 'autonomic',
+            serverStatus: 'ACTIVE',
+            persona: '',
+            isDeveloperConsole: '' === 'true',
+            isPreview: 'false' === 'true',
+            permissions: []
+        },
+        logHasFeatureError: function(message) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', '/api/internal/client-logging/has-feature-error', true);
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.send(JSON.stringify({
+              message: message
+            }));
+        }
+
+    };
+</script>
+<script>var _features=["MONTHLY_FLAG_2019_05","MONTHLY_FLAG_2018_10","MONTHLY_FLAG_2019_04","APP_NOTES","MONTHLY_FLAG_2019_06","MONTHLY_FLAG_2019_09","API_ACCESS_MANAGEMENT","MONTHLY_FLAG_2019_10","MONTHLY_FLAG_2018_12","MONTHLY_FLAG_2018_09","MONTHLY_FLAG_2019_02","MONTHLY_FLAG_2019_03","MONTHLY_FLAG_2019_07","MONTHLY_FLAG_2019_01","MONTHLY_FLAG_2018_11","APP_REQUEST_APPROVAL_WORKFLOW","MONTHLY_FLAG_2019_08"];</script><script>window.okta || (window.okta = {}); okta.cdnUrlHostname = "//ok6static.oktacdn.com"; okta.cdnPerformCheck = false;</script><script>window.okta || (window.okta = {});window.okta.mixpanel = true;window.okta.mixpanelTrackingSamplingFactors = {"_DEFAULT":1.0};</script><script src="https://ok6static.oktacdn.com/assets/js/jquery-1.12.4.min.e93c5a2265fbe2a3e96fe19159fc9a84.js" crossorigin="anonymous" integrity="sha384-KA5uVfsh/aGN4nZ9iqQ+CAYy0emdYEnjgFsPzqxBi2AMeqLX5qoCiY4ICzIg61TX" type="text/javascript"></script><!--[if lt IE 9]><script src="https://ok6static.oktacdn.com/assets/enduser/js/vendor/css3-mediaqueries.fa295f0132f5335f352071ca3613a94a.js" crossorigin="anonymous" integrity="sha384-7pU2GSgyec3nzQMUNSuzanfJelP9UCOyHil0bOv+WnPKSS9lNA/tcxPyr7NV2w6c" type="text/javascript"></script><![endif]-->
+
+<script>if (window.module) module = window.module;</script>
+
+</head>
+<body id="app" class="enduser-app   ">
+<noscript><div id="noscript-mask"></div><div id="noscript-msg" class="infobox infobox-warning infobox-compact"><span class="icon warning-16"></span><h3>Javascript is disabled on your browser.</h3><p>Please enable Javascript and refresh this page to use Okta.</p></div></noscript>
+
+<div id="container">
+<link href="https://ok6static.oktacdn.com/assets/css/sections/interstitial.a54a1edc95056b8486c088d765565d49.css" type="text/css" rel="stylesheet"/><script>
+    var interstitialMinWaitTime = 1200;
+    </script>
+<!--[if lte IE 9]>
+            <style type="text/css">
+                #okta-auth-spin {
+                    top: 35%;
+                }
+            </style>
+        <![endif]-->
+
+        <!--[if lte IE 8]>
+            <style type="text/css">
+                #okta-auth-band {
+                    height: 200px;
+                }
+            </style>
+        <![endif]-->
+
+        <div id="okta-interstitial-wrap">
+                <div class="okta-auth-mask-new-interstitial"></div>
+        <div class="new-interstitial" id="new-interstitial">
+        <div id="okta-auth-band">
+            <img src="https://ok6static.oktacdn.com/assets/img/ui/indicators/new_interstitial_static.9481d4731547cec09b26be142dbeec61.png" width="376" height="160" alt="Please wait" class="new-img-static"/><img src="https://ok6static.oktacdn.com/assets/img/ui/indicators/new_interstitial.c41c3b6f3a84458aca9a5919f238fbe3.gif" width="376" height="160" alt="Please wait" class="new-img"/><img src="https://ok6static.oktacdn.com/assets/img/logos/okta_watermark.4a7f2ccf7d0a787cff6f59fb67f72843.png" width="106" height="36" alt="Okta" class="okta-logo"/><div id="okta-auth-spin"></div>
+                    <div id="okta-auth-spin-small"></div>
+                <h1 id="okta-auth-heading" class ='signing-in-text'>Signing in to Amazon Web Services</h1>
+        </div>
+        </div> <!--new-interstitial -->
+        </div> <!--okta-interstitial-wrap -->
+
+        <script type="text/javascript">
+            $(function(){
+                var isFFSVGFixEnabled = 'false';
+                if ($('#okta-auth-spin').hasClass('android-spinner')) {
+                    return;
+                }
+
+                // Remove gif animation for Safari
+                var isSafari = /AppleWebKit/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
+                if (isFFSVGFixEnabled && isSafari) {
+                    $('.new-img').hide(0);
+                } else {
+                    $('.new-img').on('load', function(evt){
+                        //gif loaded correctly, fade out static asset and fade in gif
+                        //making sure we show the graphic before the form submit happens in 200ms
+                        $('.new-img-static').hide(0,function(){
+                            $('.new-img').show(0);
+                        });
+                    });
+                }
+
+                //For cached images with src the load event fires just before you add a listener for it. Hence setting the source again to make sure the event handlers fire in the right order.
+                var assetUrl = $('.new-img').attr('src');
+                $('.new-img').attr('src', assetUrl);
+
+                var standard = document.getElementById('okta-auth-spin');
+                var small = document.getElementById('okta-auth-spin-small');
+
+                var optsStandard = {
+                    lines: 9, // The number of lines to draw
+                    length: 0, // The length of each line
+                    width: 8, // The line thickness
+                    radius: 21, // The radius of the inner circle
+                    corners: 1, // Corner roundness (0..1)
+                    rotate: 0, // The rotation offset
+                    direction: 1, // 1: clockwise, -1: counterclockwise
+                    color: '#fff', // #rgb or #rrggbb
+                    speed: 1, // Rounds per second
+                    trail: 60, // Afterglow percentage
+                    shadow: false, // Whether to render a shadow
+                    hwaccel: false, // Whether to use hardware acceleration
+                    className: 'okta-auth-spinner', // The CSS class to assign to the spinner
+                    zIndex: 2e9, // The z-index (defaults to 2000000000)
+                    top: 'auto', // Top position relative to parent in px
+                    left: 'auto' // Left position relative to parent in px
+                };
+
+                var optsSmall = {
+                    lines: 9, // The number of lines to draw
+                    length: 0, // The length of each line
+                    width: 6, // The line thickness
+                    radius: 14, // The radius of the inner circle
+                    corners: 1, // Corner roundness (0..1)
+                    rotate: 0, // The rotation offset
+                    direction: 1, // 1: clockwise, -1: counterclockwise
+                    color: '#fff', // #rgb or #rrggbb
+                    speed: 1, // Rounds per second
+                    trail: 60, // Afterglow percentage
+                    shadow: false, // Whether to render a shadow
+                    hwaccel: false, // Whether to use hardware acceleration
+                    className: 'okta-auth-spinner', // The CSS class to assign to the spinner
+                    zIndex: 2e9, // The z-index (defaults to 2000000000)
+                    top: 'auto', // Top position relative to parent in px
+                    left: 'auto' // Left position relative to parent in px
+                };
+                if (typeof Spinner === 'function') {
+                    var spinnerStandard = new Spinner(optsStandard);
+                    var spinnerSmall = new Spinner(optsSmall);
+
+                    spinnerStandard.spin(standard);
+                    spinnerSmall.spin(small);
+                }
+
+            });
+        </script>
+    <form id="appForm" action="https&#x3a;&#x2f;&#x2f;signin.aws.amazon.com&#x2f;saml" method="POST">
+    <input name="SAMLResponse" type="hidden" value="PD94bWwgdmVyc2lvbj0iMS4wIj8+CjxzYW1sMnA6UmVzcG9uc2UgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnhzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYSIgRGVzdGluYXRpb249Imh0dHA6Ly9sb2NhbGhvc3Q6ODg4OC9zaW1wbGVzYW1scGhwL3d3dy9tb2R1bGUucGhwL3NhbWwvc3Avc2FtbDItYWNzLnBocC9leGFtcGxlLW9rdGEtY29tIiBJRD0iaWQzMDQwNjc1ODAwNDYzNjU0NDE0NzIyMDM4NTMiIEluUmVzcG9uc2VUbz0iXzJiMTZjYWVjYjIxODA0ZDAyNzFjN2I0NTczNDk3OGEzMWIxMjJjMGI5YSIgSXNzdWVJbnN0YW50PSIyMDE3LTAyLTAyVDAzOjEzOjA1LjExNFoiIFZlcnNpb249IjIuMCI+CiAgICA8c2FtbDI6SXNzdWVyIHhtbG5zOnNhbWwyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIiBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OmVudGl0eSI+aHR0cDovL3d3dy5vcmduYW1lLm9rdGEuY29tPC9zYW1sMjpJc3N1ZXI+CiAgICA8ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj4KICAgICAgICA8ZHM6U2lnbmVkSW5mbz4KICAgICAgICAgICAgPGRzOkNhbm9uaWNhbGl6YXRpb25NZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz4KICAgICAgICAgICAgPGRzOlNpZ25hdHVyZU1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZHNpZy1tb3JlI3JzYS1zaGEyNTYiLz4KICAgICAgICAgICAgPGRzOlJlZmVyZW5jZSBVUkk9IiNpZDMwNDA2NzU4MDA0NTM2NTQ0MTQ3MjMwMzg1MyI+CiAgICAgICAgICAgICAgICA8ZHM6VHJhbnNmb3Jtcz4KICAgICAgICAgICAgICAgICAgICA8ZHM6VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI2VudmVsb3BlZC1zaWduYXR1cmUiLz4KICAgICAgICAgICAgICAgICAgICA8ZHM6VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIj4KICAgICAgICAgICAgICAgICAgICAgICAgPGVjOkluY2x1c2l2ZU5hbWVzcGFjZXMgeG1sbnM6ZWM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIgUHJlZml4TGlzdD0ieHMiLz4KICAgICAgICAgICAgICAgICAgICA8L2RzOlRyYW5zZm9ybT4KICAgICAgICAgICAgICAgIDwvZHM6VHJhbnNmb3Jtcz4KICAgICAgICAgICAgICAgIDxkczpEaWdlc3RNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGVuYyNzaGEyNTYiLz4KICAgICAgICAgICAgICAgIDxkczpEaWdlc3RWYWx1ZT5oRjZyOWxrZVRSdmdiSkEvMGJjOHlrdkNxRVM4clV6dVc5WVlTaG1sUXZvPTwvZHM6RGlnZXN0VmFsdWU+CiAgICAgICAgICAgIDwvZHM6UmVmZXJlbmNlPgogICAgICAgIDwvZHM6U2lnbmVkSW5mbz4KICAgICAgICA8ZHM6U2lnbmF0dXJlVmFsdWU+STgyZ29ZeFRyNXEyRCtlV3ZqNk8rRG5xT0cveHRBU3RpcnJnVFkxZHBCUTJwbHJJNmU0dDFnNnN0WFo0Nyt5M3FYODF4U1B2MnBjVlhwNk5saHhVMnR3QksrMXhMMnRkdXltVnJ3V1dJNFZBVGR4NVNqbWNZYUg1RkthRG4xZWU2VnM3WXRZRFpKekpEcUdlLys1U2FlbW5zdHJWbVhiam1Ld0Rpbk81dHR2TnNXOFIxTEJGK1p4cjh0aSsySmtnZ245UFJvWXArSi9NWjUrc01aZ2t5MkhCNzB1MHZyd2lMKzRFTEQvYXZqOEZlZUhCTUp3cWxsV1ExcUNaNUVMdFJMWEFOQ05nZTNVcjM5MkhrR3k0SEIydDFFVmNNQU84d1pwQXpITW5wNklvelFNOCsvMmFQZERUYXBudjRrT2o4c2N4c29abGJNSEFaQ2dmbDNsajd3PT08L2RzOlNpZ25hdHVyZVZhbHVlPgogICAgICAgIDxkczpLZXlJbmZvPgogICAgICAgICAgICA8ZHM6WDUwOURhdGE+CiAgICAgICAgICAgICAgICA8ZHM6WDUwOUNlcnRpZmljYXRlPk1JSURwRENDQW95Z0F3SUJBZ0lHQVZWZnE4NkdNQTBHQ1NxR1NJYjNEUUVCQ3dVQU1JR1NNUXN3Q1FZRFZRUUdFd0pWVXpFVE1CRUcKQTFVRUNBd0tRMkZzYVdadmNtNXBZVEVXTUJRR0ExVUVCd3dOVTJGdUlFWnlZVzVqYVhOamJ6RU5NQXNHQTFVRUNnd0VUMnQwWVRFVQpNQklHQTFVRUN3d0xVMU5QVUhKdmRtbGtaWEl4RXpBUkJnTlZCQU1NQ21SbGRuTjFjSEJ2Y25ReEhEQWFCZ2txaGtpRzl3MEJDUUVXCkRXbHVabTlBYjJ0MFlTNWpiMjB3SGhjTk1UWXdOakUzTVRnME1USXlXaGNOTWpZd05qRTNNVGcwTWpJeVdqQ0JrakVMTUFrR0ExVUUKQmhNQ1ZWTXhFekFSQmdOVkJBZ01Da05oYkdsbWIzSnVhV0V4RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJselkyOHhEVEFMQmdOVgpCQW9NQkU5cmRHRXhGREFTQmdOVkJBc01DMU5UVDFCeWIzWnBaR1Z5TVJNd0VRWURWUVFEREFwa1pYWnpkWEJ3YjNKME1Sd3dHZ1lKCktvWklodmNOQVFrQkZnMXBibVp2UUc5cmRHRXVZMjl0TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEKcXAxMFZKdktqcUlFazMwYnYwV1B3NlhoWnRUbTE5WGZMcnd5SFJHMWFZUXNoa2NJb2xTOVZ2cDVTZEw2ZERFY3RkZjVkem5yUVRscgo4UStMVUlDNkpHblZ6QS9xZ0MxVXBzWFlkZmFvZDBjMzVHTThIRHNIbmkwTU5Vbkh0LzJNcURXNlBrWW9JZGpuaURwMjF3T0NpT1JFCkZHdUMxa1VRUUpZMnlROGJRSlZFS0NFeUlVUEdYTE1jUWxiQjB2QWtiR2VxejRIQ1pCWC9uN3dyLzUwTU1RejhZT0xTa3gvME9qbHMKc0dFQTZLQWJkRnV0cnZTVUtJVWVaYzRYRmZ5U205S0oxVmk4M1BwYWNPZld1S3lrdGpQUjBtQzZ3Szg3UHVOMzJib2E0blEyK0JNZgp2L3FneDRlNVJEblRZazIraVBjd042bkt4SmZTNjZrS2hwZk1kd0lEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQThSNjA3CmlMOVN4OVFLbzMxekcyeEcyNGRyWXhhV3RhNkc1WEtjUk9rRmsyWlZmUkFoUzlyeDFXRlh1Q1Y1ZS95czB6N2pJTFdLaXNUa2plZ1kKdXVicXk2YXdCYmpEUnhuVWN0ME9kWlU0c2lIV1lqdkwrU1lPVDJQazhJd2xENEhHTnNlZTZXbVVSdmZwTDJZaWI5WGM4NXFWcDFXOQp0N0dVMkdaVm5PeVU3YS9KZkFnRHc3OXo1ZEgxQlFzQ1crbnZnZU81VmdGWFZPU2Y3ZEJPQjJQbHdHNURsSDVNZ05hNjdlSDNXcjlCClJLdnd5eVRmcWZxOXBnU21COXhOVkpJZVZaYmJaR1RsTkdxSnRpMjRFMEFpSVBnZ3R4ZzVOSitISG5FUTVSeGRTc1I0ZmJNejlpMEsKL2JYdDZoUGdHdTd4WVJTdjFSZnZLY1IxTmpZazNubkQ8L2RzOlg1MDlDZXJ0aWZpY2F0ZT4KICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICA8L2RzOktleUluZm8+CiAgICA8L2RzOlNpZ25hdHVyZT4KICAgIDxzYW1sMnA6U3RhdHVzIHhtbG5zOnNhbWwycD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIj4KICAgICAgICA8c2FtbDJwOlN0YXR1c0NvZGUgVmFsdWU9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpzdGF0dXM6U3VjY2VzcyIvPgogICAgPC9zYW1sMnA6U3RhdHVzPgogICAgPHNhbWwyOkFzc2VydGlvbiB4bWxuczpzYW1sMj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgeG1sbnM6eHM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hIiBJRD0iaWQzMDQwNjc1ODAwNDY3NTk3MDE3NTkyMDM5NTEiIElzc3VlSW5zdGFudD0iMjAxNy0wMi0wMlQwMzoxMzowNS4xMTRaIiBWZXJzaW9uPSIyLjAiPgogICAgICAgIDxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6ZW50aXR5Ij5odHRwOi8vd3d3Lm9yZ25hbWUub2t0YS5jb208L3NhbWwyOklzc3Vlcj4KICAgICAgICA8ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj4KICAgICAgICAgICAgPGRzOlNpZ25lZEluZm8+CiAgICAgICAgICAgICAgICA8ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPgogICAgICAgICAgICAgICAgPGRzOlNpZ25hdHVyZU1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZHNpZy1tb3JlI3JzYS1zaGEyNTYiLz4KICAgICAgICAgICAgICAgIDxkczpSZWZlcmVuY2UgVVJJPSIjaWQzMDQwNjc1ODAwNDY3NTk3MDE3NTkyMDM5NTEiPgogICAgICAgICAgICAgICAgICAgIDxkczpUcmFuc2Zvcm1zPgogICAgICAgICAgICAgICAgICAgICAgICA8ZHM6VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI2VudmVsb3BlZC1zaWduYXR1cmUiLz4KICAgICAgICAgICAgICAgICAgICAgICAgPGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyI+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8ZWM6SW5jbHVzaXZlTmFtZXNwYWNlcyB4bWxuczplYz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIiBQcmVmaXhMaXN0PSJ4cyIvPgogICAgICAgICAgICAgICAgICAgICAgICA8L2RzOlRyYW5zZm9ybT4KICAgICAgICAgICAgICAgICAgICA8L2RzOlRyYW5zZm9ybXM+CiAgICAgICAgICAgICAgICAgICAgPGRzOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIvPgogICAgICAgICAgICAgICAgICAgIDxkczpEaWdlc3RWYWx1ZT5TOG1OaVlLUmwvRXd0Uk1VbndxTDhvTGZhQk5IcGdmMUtsMWZWbUhib1g0PTwvZHM6RGlnZXN0VmFsdWU+CiAgICAgICAgICAgICAgICA8L2RzOlJlZmVyZW5jZT4KICAgICAgICAgICAgPC9kczpTaWduZWRJbmZvPgogICAgICAgICAgICA8ZHM6U2lnbmF0dXJlVmFsdWU+aXBkU2k5SFZ1SGlzbmNYeDV4T3hUVGR5VjBpMXlNUmVjcFRXVnE1SEY4VHVuYzZHSW15QWQ3YzdiTEdJeFJWcnFXYUw0OStlS3pzL0c5MDZla1dkMy8yTzdNTVh2WGIzcDlTblFGNzRtVjkwcCtsK1BiM0NudVB1aXRoYkYyZEJnelVlK0FhZFpzOFpyZ2ZUbkMrczd6eC9aS3NqZks0SmJVTkM3emFqWGwwK1Bjb0pVaWMzTlZlNUdrZGEvK2NhS0FWa0ljN0p2VDZwa3AzZ0VRaE1vd2ZiNVl0c2dPNDFITll1OTJSbUpDaWtQRUdhd2dzYzRQS3p2ck1VU1paYTUyWFlyVFRSZ3B0NlJ2WUEyUFJCdW9jRXhSUzNNMW9McEVnS3JtSjlvQ3pFU2FNSHVxdWxRYlk4bFJmWm5laGpsK3R6ZzkyVzhZTmtyUjRxUGFMbFlBPT08L2RzOlNpZ25hdHVyZVZhbHVlPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIDxkczpYNTA5RGF0YT4KICAgICAgICAgICAgICAgICAgICA8ZHM6WDUwOUNlcnRpZmljYXRlPk1JSURwRENDQW95Z0F3SUJBZ0lHQVZWZnE4NkdNQTBHQ1NxR1NJYjNEUUVCQ3dVQU1JR1NNUXN3Q1FZRFZRUUdFd0pWVXpFVE1CRUcKQTFVRUNBd0tRMkZzYVdadmNtNXBZVEVXTUJRR0ExVUVCd3dOVTJGdUlFWnlZVzVqYVhOamJ6RU5NQXNHQTFVRUNnd0VUMnQwWVRFVQpNQklHQTFVRUN3d0xVMU5QVUhKdmRtbGtaWEl4RXpBUkJnTlZCQU1NQ21SbGRuTjFjSEJ2Y25ReEhEQWFCZ2txaGtpRzl3MEJDUUVXCkRXbHVabTlBYjJ0MFlTNWpiMjB3SGhjTk1UWXdOakUzTVRnME1USXlXaGNOTWpZd05qRTNNVGcwTWpJeVdqQ0JrakVMTUFrR0ExVUUKQmhNQ1ZWTXhFekFSQmdOVkJBZ01Da05oYkdsbWIzSnVhV0V4RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJselkyOHhEVEFMQmdOVgpCQW9NQkU5cmRHRXhGREFTQmdOVkJBc01DMU5UVDFCeWIzWnBaR1Z5TVJNd0VRWURWUVFEREFwa1pYWnpkWEJ3YjNKME1Sd3dHZ1lKCktvWklodmNOQVFrQkZnMXBibVp2UUc5cmRHRXVZMjl0TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEKcXAxMFZKdktqcUlFazMwYnYwV1B3NlhoWnRUbTE5WGZMcnd5SFJHMWFZUXNoa2NJb2xTOVZ2cDVTZEw2ZERFY3RkZjVkem5yUVRscgo4UStMVUlDNkpHblZ6QS9xZ0MxVXBzWFlkZmFvZDBjMzVHTThIRHNIbmkwTU5Vbkh0LzJNcURXNlBrWW9JZGpuaURwMjF3T0NpT1JFCkZHdUMxa1VRUUpZMnlROGJRSlZFS0NFeUlVUEdYTE1jUWxiQjB2QWtiR2VxejRIQ1pCWC9uN3dyLzUwTU1RejhZT0xTa3gvME9qbHMKc0dFQTZLQWJkRnV0cnZTVUtJVWVaYzRYRmZ5U205S0oxVmk4M1BwYWNPZld1S3lrdGpQUjBtQzZ3Szg3UHVOMzJib2E0blEyK0JNZgp2L3FneDRlNVJEblRZazIraVBjd042bkt4SmZTNjZrS2hwZk1kd0lEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQThSNjA3CmlMOVN4OVFLbzMxekcyeEcyNGRyWXhhV3RhNkc1WEtjUk9rRmsyWlZmUkFoUzlyeDFXRlh1Q1Y1ZS95czB6N2pJTFdLaXNUa2plZ1kKdXVicXk2YXdCYmpEUnhuVWN0ME9kWlU0c2lIV1lqdkwrU1lPVDJQazhJd2xENEhHTnNlZTZXbVVSdmZwTDJZaWI5WGM4NXFWcDFXOQp0N0dVMkdaVm5PeVU3YS9KZkFnRHc3OXo1ZEgxQlFzQ1crbnZnZU81VmdGWFZPU2Y3ZEJPQjJQbHdHNURsSDVNZ05hNjdlSDNXcjlCClJLdnd5eVRmcWZxOXBnU21COXhOVkpJZVZaYmJaR1RsTkdxSnRpMjRFMEFpSVBnZ3R4ZzVOSitISG5FUTVSeGRTc1I0ZmJNejlpMEsKL2JYdDZoUGdHdTd4WVJTdjFSZnZLY1IxTmpZazNubkQ8L2RzOlg1MDlDZXJ0aWZpY2F0ZT4KICAgICAgICAgICAgICAgIDwvZHM6WDUwOURhdGE+CiAgICAgICAgICAgIDwvZHM6S2V5SW5mbz4KICAgICAgICA8L2RzOlNpZ25hdHVyZT4KICAgICAgICA8c2FtbDI6U3ViamVjdCB4bWxuczpzYW1sMj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiI+CiAgICAgICAgICAgIDxzYW1sMjpOYW1lSUQgRm9ybWF0PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoxLjE6bmFtZWlkLWZvcm1hdDp1bnNwZWNpZmllZCI+dXNlck5hbWU8L3NhbWwyOk5hbWVJRD4KICAgICAgICAgICAgPHNhbWwyOlN1YmplY3RDb25maXJtYXRpb24gTWV0aG9kPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6Y206YmVhcmVyIj4KICAgICAgICAgICAgICAgIDxzYW1sMjpTdWJqZWN0Q29uZmlybWF0aW9uRGF0YSBJblJlc3BvbnNlVG89Il8yYjE2Y2FlY2IyMTgwNGQwMjcxYzdiNDU3MzQ5NzhhMzFiMTIyYzBiOWEiIE5vdE9uT3JBZnRlcj0iMjAxNy0wMi0wMlQwMzoxODowNS4xMTRaIiBSZWNpcGllbnQ9Imh0dHA6Ly9sb2NhbGhvc3Q6ODg4OC9zaW1wbGVzYW1scGhwL3d3dy9tb2R1bGUucGhwL3NhbWwvc3Avc2FtbDItYWNzLnBocC9leGFtcGxlLW9rdGEtY29tIi8+CiAgICAgICAgICAgIDwvc2FtbDI6U3ViamVjdENvbmZpcm1hdGlvbj4KICAgICAgICA8L3NhbWwyOlN1YmplY3Q+CiAgICAgICAgPHNhbWwyOkNvbmRpdGlvbnMgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIE5vdEJlZm9yZT0iMjAxNy0wMi0wMlQwMzowODowNS4xMTRaIiBOb3RPbk9yQWZ0ZXI9IjIwMTctMDItMDJUMDM6MTg6MDUuMTE0WiI+CiAgICAgICAgICAgIDxzYW1sMjpBdWRpZW5jZVJlc3RyaWN0aW9uPgogICAgICAgICAgICAgICAgPHNhbWwyOkF1ZGllbmNlPmh0dHA6Ly9sb2NhbGhvc3Q6ODg4OC9zaW1wbGVzYW1scGhwL3d3dy9tb2R1bGUucGhwL3NhbWwvc3AvbWV0YWRhdGEucGhwL2V4YW1wbGUtb2t0YS1jb208L3NhbWwyOkF1ZGllbmNlPgogICAgICAgICAgICA8L3NhbWwyOkF1ZGllbmNlUmVzdHJpY3Rpb24+CiAgICAgICAgPC9zYW1sMjpDb25kaXRpb25zPgogICAgICAgIDxzYW1sMjpBdXRoblN0YXRlbWVudCB4bWxuczpzYW1sMj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgQXV0aG5JbnN0YW50PSIyMDE3LTAyLTAyVDAzOjEzOjA1LjExNFoiIFNlc3Npb25JbmRleD0iXzJiMTZjYWVjYjIxODA0ZDAyNzFjN2I0NTczNDk3OGEzMWIxMjJjMGI5YSI+CiAgICAgICAgICAgIDxzYW1sMjpBdXRobkNvbnRleHQ+CiAgICAgICAgICAgICAgICA8c2FtbDI6QXV0aG5Db250ZXh0Q2xhc3NSZWY+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFjOmNsYXNzZXM6UGFzc3dvcmRQcm90ZWN0ZWRUcmFuc3BvcnQ8L3NhbWwyOkF1dGhuQ29udGV4dENsYXNzUmVmPgogICAgICAgICAgICA8L3NhbWwyOkF1dGhuQ29udGV4dD4KICAgICAgICA8L3NhbWwyOkF1dGhuU3RhdGVtZW50PgogICAgICAgIDxzYW1sMjpBdHRyaWJ1dGVTdGF0ZW1lbnQgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iPgo8c2FtbDI6QXR0cmlidXRlIE5hbWU9Imh0dHBzOi8vYXdzLmFtYXpvbi5jb20vU0FNTC9BdHRyaWJ1dGVzL1JvbGUiIE5hbWVGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphdHRybmFtZS1mb3JtYXQ6dXJpIj4KICAgICAgICAgICAgICAgIDxzYW1sMjpBdHRyaWJ1dGVWYWx1ZSB4bWxuczp4cz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhzaTp0eXBlPSJ4czpzdHJpbmciPmFybjphd3M6aWFtOjowMDAwMDAwMDAwMDA6c2FtbC1wcm92aWRlci9PS1RBLGFybjphd3M6aWFtOjowMDAwMDAwMDAwMDA6cm9sZS9jbG93bnMuYXJlLnNjYXJ5LnNhbWxyb2xlPC9zYW1sMjpBdHRyaWJ1dGVWYWx1ZT4KICAgICAgICAgICAgICAgIDxzYW1sMjpBdHRyaWJ1dGVWYWx1ZSB4bWxuczp4cz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhzaTp0eXBlPSJ4czpzdHJpbmciPmFybjphd3M6aWFtOjowMDAwMDAwMDAwMDA6cm9sZS9zaGFya3MuYXJlLmZyaWVuZHMuc2FtbHJvbGUsYXJuOmF3czppYW06OjAwMDAwMDAwMDAwMDpzYW1sLXByb3ZpZGVyL09LVEE8L3NhbWwyOkF0dHJpYnV0ZVZhbHVlPgogICAgICAgICAgICA8L3NhbWwyOkF0dHJpYnV0ZT4KICAgICAgICA8L3NhbWwyOkF0dHJpYnV0ZVN0YXRlbWVudD4KICAgIDwvc2FtbDI6QXNzZXJ0aW9uPgo8L3NhbWwycDpSZXNwb25zZT4K">
+    <input name="RelayState" type="hidden" value=""/>
+</form>
+
+<script src="https://ok6static.oktacdn.com/assets/js/app/sso/interstitial.474dce61acfac4a4d016921943cf2a68.js" crossorigin="anonymous" integrity="sha384-rIRjIHrr5XnyB1DG8t+uL1F3e5asM+gYMial0fj56hCWADEBdp3BiwtOAnNpU7Zc" type="text/javascript"></script></div>
+<!-- close #container -->
+</body>
+</html>

--- a/vendor/github.com/h2non/parth/LICENSE
+++ b/vendor/github.com/h2non/parth/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 codemodus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/h2non/parth/README.md
+++ b/vendor/github.com/h2non/parth/README.md
@@ -1,0 +1,196 @@
+# parth
+
+    go get -u github.com/h2non/parth
+
+Package parth provides path parsing for segment unmarshaling and slicing. In
+other words, parth provides simple and flexible access to (URL) path parameters.
+
+Along with string, all basic non-alias types are supported. An interface is
+available for implementation by user-defined types. When handling an int, uint,
+or float of any size, the first valid value within the specified segment will be
+used.
+
+## Usage
+
+```go
+Variables
+func Segment(path string, i int, v interface{}) error
+func Sequent(path, key string, v interface{}) error
+func Span(path string, i, j int) (string, error)
+func SubSeg(path, key string, i int, v interface{}) error
+func SubSpan(path, key string, i, j int) (string, error)
+type Parth
+    func New(path string) *Parth
+    func NewBySpan(path string, i, j int) *Parth
+    func NewBySubSpan(path, key string, i, j int) *Parth
+    func (p *Parth) Err() error
+    func (p *Parth) Segment(i int, v interface{})
+    func (p *Parth) Sequent(key string, v interface{})
+    func (p *Parth) Span(i, j int) string
+    func (p *Parth) SubSeg(key string, i int, v interface{})
+    func (p *Parth) SubSpan(key string, i, j int) string
+type Unmarshaler
+```
+
+### Setup ("By Index")
+
+```go
+import (
+    "fmt"
+
+    "github.com/codemodus/parth"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    var s string
+    if err := parth.Segment(r.URL.Path, 4, &s); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+    }
+
+    fmt.Println(r.URL.Path)
+    fmt.Printf("%v (%T)\n", s, s)
+
+    // Output:
+    // /some/path/things/42/others/3
+    // others (string)
+}
+```
+
+### Setup ("By Key")
+
+```go
+import (
+    "fmt"
+
+    "github.com/codemodus/parth"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    var i int64
+    if err := parth.Sequent(r.URL.Path, "things", &i); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+    }
+
+    fmt.Println(r.URL.Path)
+    fmt.Printf("%v (%T)\n", i, i)
+
+    // Output:
+    // /some/path/things/42/others/3
+    // 42 (int64)
+}
+```
+
+### Setup (Parth Type)
+
+```go
+import (
+    "fmt"
+
+    "github.com/codemodus/parth"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    var s string
+    var f float32
+
+    p := parth.New(r.URL.Path)
+    p.Segment(2, &s)
+    p.SubSeg("key", 1, &f)
+    if err := p.Err(); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+    }
+
+    fmt.Println(r.URL.Path)
+    fmt.Printf("%v (%T)\n", s, s)
+    fmt.Printf("%v (%T)\n", f, f)
+
+    // Output:
+    // /zero/one/two/key/four/5.5/six
+    // two (string)
+    // 5.5 (float32)
+}
+```
+
+### Setup (Unmarshaler)
+
+```go
+import (
+    "fmt"
+
+    "github.com/codemodus/parth"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    /*
+        type mytype []byte
+
+        func (m *mytype) UnmarshalSegment(seg string) error {
+            *m = []byte(seg)
+        }
+    */
+
+    var m mytype
+    if err := parth.Segment(r.URL.Path, 4, &m); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+    }
+
+    fmt.Println(r.URL.Path)
+    fmt.Printf("%v == %q (%T)\n", m, m, m)
+
+    // Output:
+    // /zero/one/two/key/four/5.5/six
+    // [102 111 117 114] == "four" (mypkg.mytype)
+}
+```
+
+## More Info
+
+### Keep Using http.HandlerFunc And Minimize context.Context Usage
+
+The most obvious use case for parth is when working with any URL path such as
+the one found at http.Request.URL.Path. parth is fast enough that it can be used
+multiple times in place of a single use of similar router-parameter schemes or
+even context.Context. There is no need to use an alternate http handler function
+definition in order to pass data that is already being passed. The http.Request
+type already holds URL data and parth is great at handling it. Additionally,
+parth takes care of parsing selected path segments into the types actually
+needed. Parth not only does more, it's usually faster and less intrusive than
+the alternatives.
+
+### Indexes
+
+If an index is negative, the negative count begins with the last segment.
+Providing a 0 for the second index is a special case which acts as an alias for
+the end of the path. An error is returned if: 1. Any index is out of range of
+the path; 2. When there are two indexes, the first index does not precede the
+second index.
+
+### Keys
+
+If a key is involved, functions will only handle the portion of the path
+subsequent to the provided key. An error is returned if the key cannot be found
+in the path.
+
+### First Whole, First Decimal (Restated - Important!)
+
+When handling an int, uint, or float of any size, the first valid value within
+the specified segment will be used.
+
+## Documentation
+
+View the [GoDoc](http://godoc.org/github.com/codemodus/parth)
+
+## Benchmarks
+
+    Go 1.11
+    benchmark                             iter       time/iter   bytes alloc        allocs
+    ---------                             ----       ---------   -----------        ------
+    BenchmarkSegmentString-8          30000000     39.60 ns/op        0 B/op   0 allocs/op
+    BenchmarkSegmentInt-8             20000000     65.60 ns/op        0 B/op   0 allocs/op
+    BenchmarkSegmentIntNegIndex-8     20000000     86.60 ns/op        0 B/op   0 allocs/op
+    BenchmarkSpan-8                  100000000     18.20 ns/op        0 B/op   0 allocs/op
+    BenchmarkStdlibSegmentString-8     5000000    454.00 ns/op       50 B/op   2 allocs/op
+    BenchmarkStdlibSegmentInt-8        3000000    526.00 ns/op       50 B/op   2 allocs/op
+    BenchmarkStdlibSpan-8              3000000    518.00 ns/op       69 B/op   2 allocs/op
+    BenchmarkContextLookupSetGet-8     1000000   1984.00 ns/op      480 B/op   6 allocs/op
+

--- a/vendor/github.com/h2non/parth/go.mod
+++ b/vendor/github.com/h2non/parth/go.mod
@@ -1,0 +1,1 @@
+module github.com/h2non/parth

--- a/vendor/github.com/h2non/parth/parth.go
+++ b/vendor/github.com/h2non/parth/parth.go
@@ -1,0 +1,349 @@
+// Package parth provides path parsing for segment unmarshaling and slicing. In
+// other words, parth provides simple and flexible access to (URL) path
+// parameters.
+//
+// Along with string, all basic non-alias types are supported. An interface is
+// available for implementation by user-defined types. When handling an int,
+// uint, or float of any size, the first valid value within the specified
+// segment will be used.
+package parth
+
+import (
+	"errors"
+)
+
+// Unmarshaler is the interface implemented by types that can unmarshal a path
+// segment representation of themselves. It is safe to assume that the segment
+// data will not include slashes.
+type Unmarshaler interface {
+	UnmarshalSegment(string) error
+}
+
+// Err{Name} values facilitate error identification.
+var (
+	ErrUnknownType = errors.New("unknown type provided")
+
+	ErrFirstSegNotFound = errors.New("first segment not found by index")
+	ErrLastSegNotFound  = errors.New("last segment not found by index")
+	ErrSegOrderReversed = errors.New("first segment must precede last segment")
+	ErrKeySegNotFound   = errors.New("segment not found by key")
+
+	ErrDataUnparsable = errors.New("data cannot be parsed")
+)
+
+// Segment locates the path segment indicated by the index i and unmarshals it
+// into the provided type v. If the index is negative, the negative count
+// begins with the last segment. An error is returned if: 1. The type is not a
+// pointer to an instance of one of the basic non-alias types and does not
+// implement the Unmarshaler interface; 2. The index is out of range of the
+// path; 3. The located path segment data cannot be parsed as the provided type
+// or if an error is returned when using a provided Unmarshaler implementation.
+func Segment(path string, i int, v interface{}) error { //nolint
+	var err error
+
+	switch v := v.(type) {
+	case *bool:
+		*v, err = segmentToBool(path, i)
+
+	case *float32:
+		var f float64
+		f, err = segmentToFloatN(path, i, 32)
+		*v = float32(f)
+
+	case *float64:
+		*v, err = segmentToFloatN(path, i, 64)
+
+	case *int:
+		var n int64
+		n, err = segmentToIntN(path, i, 0)
+		*v = int(n)
+
+	case *int16:
+		var n int64
+		n, err = segmentToIntN(path, i, 16)
+		*v = int16(n)
+
+	case *int32:
+		var n int64
+		n, err = segmentToIntN(path, i, 32)
+		*v = int32(n)
+
+	case *int64:
+		*v, err = segmentToIntN(path, i, 64)
+
+	case *int8:
+		var n int64
+		n, err = segmentToIntN(path, i, 8)
+		*v = int8(n)
+
+	case *string:
+		*v, err = segmentToString(path, i)
+
+	case *uint:
+		var n uint64
+		n, err = segmentToUintN(path, i, 0)
+		*v = uint(n)
+
+	case *uint16:
+		var n uint64
+		n, err = segmentToUintN(path, i, 16)
+		*v = uint16(n)
+
+	case *uint32:
+		var n uint64
+		n, err = segmentToUintN(path, i, 32)
+		*v = uint32(n)
+
+	case *uint64:
+		*v, err = segmentToUintN(path, i, 64)
+
+	case *uint8:
+		var n uint64
+		n, err = segmentToUintN(path, i, 8)
+		*v = uint8(n)
+
+	case Unmarshaler:
+		var s string
+		s, err = segmentToString(path, i)
+		if err == nil {
+			err = v.UnmarshalSegment(s)
+		}
+
+	default:
+		err = ErrUnknownType
+	}
+
+	return err
+}
+
+// Sequent is similar to Segment, but uses a key to locate a segment and then
+// unmarshal the subsequent segment. It is a simple wrapper over SubSeg with an
+// index of 0.
+func Sequent(path, key string, v interface{}) error {
+	return SubSeg(path, key, 0, v)
+}
+
+// Span returns the path segments between two segment indexes i and j including
+// the first segment. If an index is negative, the negative count begins with
+// the last segment. Providing a 0 for the last index j is a special case which
+// acts as an alias for the end of the path. If the first segment does not begin
+// with a slash and it is part of the requested span, no slash will be added. An
+// error is returned if: 1. Either index is out of range of the path; 2. The
+// first index i does not precede the last index j.
+func Span(path string, i, j int) (string, error) {
+	var f, l int
+	var ok bool
+
+	if i < 0 {
+		f, ok = segStartIndexFromEnd(path, i)
+	} else {
+		f, ok = segStartIndexFromStart(path, i)
+	}
+	if !ok {
+		return "", ErrFirstSegNotFound
+	}
+
+	if j > 0 {
+		l, ok = segEndIndexFromStart(path, j)
+	} else {
+		l, ok = segEndIndexFromEnd(path, j)
+	}
+	if !ok {
+		return "", ErrLastSegNotFound
+	}
+
+	if f == l {
+		return "", nil
+	}
+
+	if f > l {
+		return "", ErrSegOrderReversed
+	}
+
+	return path[f:l], nil
+}
+
+// SubSeg is similar to Segment, but only handles the portion of the path
+// subsequent to the provided key. For example, to access the segment
+// immediately after a key, an index of 0 should be provided (see Sequent). An
+// error is returned if the key cannot be found in the path.
+func SubSeg(path, key string, i int, v interface{}) error { //nolint
+	var err error
+
+	switch v := v.(type) {
+	case *bool:
+		*v, err = subSegToBool(path, key, i)
+
+	case *float32:
+		var f float64
+		f, err = subSegToFloatN(path, key, i, 32)
+		*v = float32(f)
+
+	case *float64:
+		*v, err = subSegToFloatN(path, key, i, 64)
+
+	case *int:
+		var n int64
+		n, err = subSegToIntN(path, key, i, 0)
+		*v = int(n)
+
+	case *int16:
+		var n int64
+		n, err = subSegToIntN(path, key, i, 16)
+		*v = int16(n)
+
+	case *int32:
+		var n int64
+		n, err = subSegToIntN(path, key, i, 32)
+		*v = int32(n)
+
+	case *int64:
+		*v, err = subSegToIntN(path, key, i, 64)
+
+	case *int8:
+		var n int64
+		n, err = subSegToIntN(path, key, i, 8)
+		*v = int8(n)
+
+	case *string:
+		*v, err = subSegToString(path, key, i)
+
+	case *uint:
+		var n uint64
+		n, err = subSegToUintN(path, key, i, 0)
+		*v = uint(n)
+
+	case *uint16:
+		var n uint64
+		n, err = subSegToUintN(path, key, i, 16)
+		*v = uint16(n)
+
+	case *uint32:
+		var n uint64
+		n, err = subSegToUintN(path, key, i, 32)
+		*v = uint32(n)
+
+	case *uint64:
+		*v, err = subSegToUintN(path, key, i, 64)
+
+	case *uint8:
+		var n uint64
+		n, err = subSegToUintN(path, key, i, 8)
+		*v = uint8(n)
+
+	case Unmarshaler:
+		var s string
+		s, err = subSegToString(path, key, i)
+		if err == nil {
+			err = v.UnmarshalSegment(s)
+		}
+
+	default:
+		err = ErrUnknownType
+	}
+
+	return err
+}
+
+// SubSpan is similar to Span, but only handles the portion of the path
+// subsequent to the provided key. An error is returned if the key cannot be
+// found in the path.
+func SubSpan(path, key string, i, j int) (string, error) {
+	si, ok := segIndexByKey(path, key)
+	if !ok {
+		return "", ErrKeySegNotFound
+	}
+
+	if i >= 0 {
+		i++
+	}
+	if j > 0 {
+		j++
+	}
+
+	s, err := Span(path[si:], i, j)
+	if err != nil {
+		return "", err
+	}
+
+	return s, nil
+}
+
+// Parth manages path and error data for processing a single path multiple
+// times while error checking only once. Only the first encountered error is
+// stored as all subsequent calls to Parth methods that can error are elided.
+type Parth struct {
+	path string
+	err  error
+}
+
+// New constructs a pointer to an instance of Parth around the provided path.
+func New(path string) *Parth {
+	return &Parth{path: path}
+}
+
+// NewBySpan constructs a pointer to an instance of Parth after preprocessing
+// the provided path with Span.
+func NewBySpan(path string, i, j int) *Parth {
+	s, err := Span(path, i, j)
+	return &Parth{s, err}
+}
+
+// NewBySubSpan constructs a pointer to an instance of Parth after
+// preprocessing the provided path with SubSpan.
+func NewBySubSpan(path, key string, i, j int) *Parth {
+	s, err := SubSpan(path, key, i, j)
+	return &Parth{s, err}
+}
+
+// Err returns the first error encountered by the *Parth receiver.
+func (p *Parth) Err() error {
+	return p.err
+}
+
+// Segment operates the same as the package-level function Segment.
+func (p *Parth) Segment(i int, v interface{}) {
+	if p.err != nil {
+		return
+	}
+
+	p.err = Segment(p.path, i, v)
+}
+
+// Sequent operates the same as the package-level function Sequent.
+func (p *Parth) Sequent(key string, v interface{}) {
+	p.SubSeg(key, 0, v)
+}
+
+// Span operates the same as the package-level function Span.
+func (p *Parth) Span(i, j int) string {
+	if p.err != nil {
+		return ""
+	}
+
+	s, err := Span(p.path, i, j)
+	p.err = err
+
+	return s
+}
+
+// SubSeg operates the same as the package-level function SubSeg.
+func (p *Parth) SubSeg(key string, i int, v interface{}) {
+	if p.err != nil {
+		return
+	}
+
+	p.err = SubSeg(p.path, key, i, v)
+}
+
+// SubSpan operates the same as the package-level function SubSpan.
+func (p *Parth) SubSpan(key string, i, j int) string {
+	if p.err != nil {
+		return ""
+	}
+
+	s, err := SubSpan(p.path, key, i, j)
+	p.err = err
+
+	return s
+}

--- a/vendor/github.com/h2non/parth/segindex.go
+++ b/vendor/github.com/h2non/parth/segindex.go
@@ -1,0 +1,118 @@
+package parth
+
+func segStartIndexFromStart(path string, seg int) (int, bool) {
+	if seg < 0 {
+		return 0, false
+	}
+
+	for n, ct := 0, 0; n < len(path); n++ {
+		if n > 0 && path[n] == '/' {
+			ct++
+		}
+
+		if ct == seg {
+			return n, true
+		}
+	}
+
+	return 0, false
+}
+
+func segStartIndexFromEnd(path string, seg int) (int, bool) {
+	if seg > -1 {
+		return 0, false
+	}
+
+	for n, ct := len(path)-1, 0; n >= 0; n-- {
+		if path[n] == '/' || n == 0 {
+			ct--
+		}
+
+		if ct == seg {
+			return n, true
+		}
+	}
+
+	return 0, false
+}
+
+func segEndIndexFromStart(path string, seg int) (int, bool) {
+	if seg < 1 {
+		return 0, false
+	}
+
+	for n, ct := 0, 0; n < len(path); n++ {
+		if path[n] == '/' && n > 0 {
+			ct++
+		}
+
+		if ct == seg {
+			return n, true
+		}
+
+		if n+1 == len(path) && ct+1 == seg {
+			return n + 1, true
+		}
+	}
+
+	return 0, false
+}
+
+func segEndIndexFromEnd(path string, seg int) (int, bool) {
+	if seg > 0 {
+		return 0, false
+	}
+
+	if seg == 0 {
+		return len(path), true
+	}
+
+	if len(path) == 1 && path[0] == '/' {
+		return 0, true
+	}
+
+	for n, ct := len(path)-1, 0; n >= 0; n-- {
+		if n == 0 || path[n] == '/' {
+			ct--
+		}
+
+		if ct == seg {
+			return n, true
+		}
+
+	}
+
+	return 0, false
+}
+
+func segIndexByKey(path, key string) (int, bool) { //nolint
+	if path == "" || key == "" {
+		return 0, false
+	}
+
+	for n := 0; n < len(path); n++ {
+		si, ok := segStartIndexFromStart(path, n)
+		if !ok {
+			return 0, false
+		}
+
+		if len(path[si:]) == len(key)+1 {
+			if path[si+1:] == key {
+				return si, true
+			}
+
+			return 0, false
+		}
+
+		tmpEI, ok := segStartIndexFromStart(path[si:], 1)
+		if !ok {
+			return 0, false
+		}
+
+		if path[si+1:tmpEI+si] == key || n == 0 && path[0] != '/' && path[si:tmpEI+si] == key {
+			return si, true
+		}
+	}
+
+	return 0, false
+}

--- a/vendor/github.com/h2non/parth/segtostr.go
+++ b/vendor/github.com/h2non/parth/segtostr.go
@@ -1,0 +1,305 @@
+package parth
+
+import (
+	"strconv"
+	"unicode"
+)
+
+func segmentToBool(path string, i int) (bool, error) {
+	s, err := segmentToString(path, i)
+	if err != nil {
+		return false, err
+	}
+
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func segmentToFloatN(path string, i, size int) (float64, error) {
+	ss, err := segmentToString(path, i)
+	if err != nil {
+		return 0.0, err
+	}
+
+	s, ok := firstFloatFromString(ss)
+	if !ok {
+		return 0.0, err
+	}
+
+	v, err := strconv.ParseFloat(s, size)
+	if err != nil {
+		return 0.0, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func segmentToIntN(path string, i, size int) (int64, error) {
+	ss, err := segmentToString(path, i)
+	if err != nil {
+		return 0, err
+	}
+
+	s, ok := firstIntFromString(ss)
+	if !ok {
+		return 0, ErrDataUnparsable
+	}
+
+	v, err := strconv.ParseInt(s, 10, size)
+	if err != nil {
+		return 0, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func segmentToString(path string, i int) (string, error) {
+	j := i + 1
+	if i < 0 {
+		i--
+	}
+
+	s, err := Span(path, i, j)
+	if err != nil {
+		return "", err
+	}
+
+	if s[0] == '/' {
+		s = s[1:]
+	}
+
+	return s, nil
+}
+
+func segmentToUintN(path string, i, size int) (uint64, error) {
+	ss, err := segmentToString(path, i)
+	if err != nil {
+		return 0, err
+	}
+
+	s, ok := firstUintFromString(ss)
+	if !ok {
+		return 0, ErrDataUnparsable
+	}
+
+	v, err := strconv.ParseUint(s, 10, size)
+	if err != nil {
+		return 0, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func subSegToBool(path, key string, i int) (bool, error) {
+	s, err := subSegToString(path, key, i)
+	if err != nil {
+		return false, err
+	}
+
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func subSegToFloatN(path, key string, i, size int) (float64, error) {
+	ss, err := subSegToString(path, key, i)
+	if err != nil {
+		return 0.0, err
+	}
+
+	s, ok := firstFloatFromString(ss)
+	if !ok {
+		return 0.0, ErrDataUnparsable
+	}
+
+	v, err := strconv.ParseFloat(s, size)
+	if err != nil {
+		return 0.0, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func subSegToIntN(path, key string, i, size int) (int64, error) {
+	ss, err := subSegToString(path, key, i)
+	if err != nil {
+		return 0, err
+	}
+
+	s, ok := firstIntFromString(ss)
+	if !ok {
+		return 0, ErrDataUnparsable
+	}
+
+	v, err := strconv.ParseInt(s, 10, size)
+	if err != nil {
+		return 0, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func subSegToString(path, key string, i int) (string, error) {
+	ki, ok := segIndexByKey(path, key)
+	if !ok {
+		return "", ErrKeySegNotFound
+	}
+
+	i++
+
+	s, err := segmentToString(path[ki:], i)
+	if err != nil {
+		return "", err
+	}
+
+	return s, nil
+}
+
+func subSegToUintN(path, key string, i, size int) (uint64, error) {
+	ss, err := subSegToString(path, key, i)
+	if err != nil {
+		return 0, err
+	}
+
+	s, ok := firstUintFromString(ss)
+	if !ok {
+		return 0, ErrDataUnparsable
+	}
+
+	v, err := strconv.ParseUint(s, 10, size)
+	if err != nil {
+		return 0, ErrDataUnparsable
+	}
+
+	return v, nil
+}
+
+func firstUintFromString(s string) (string, bool) {
+	ind, l := 0, 0
+
+	for n := 0; n < len(s); n++ {
+		if unicode.IsDigit(rune(s[n])) {
+			if l == 0 {
+				ind = n
+			}
+
+			l++
+		} else {
+			if l == 0 && s[n] == '.' {
+				if n+1 < len(s) && unicode.IsDigit(rune(s[n+1])) {
+					return "0", true
+				}
+
+				break
+			}
+
+			if l > 0 {
+				break
+			}
+		}
+	}
+
+	if l == 0 {
+		return "", false
+	}
+
+	return s[ind : ind+l], true
+}
+
+func firstIntFromString(s string) (string, bool) { //nolint
+	ind, l := 0, 0
+
+	for n := 0; n < len(s); n++ {
+		if unicode.IsDigit(rune(s[n])) {
+			if l == 0 {
+				ind = n
+			}
+
+			l++
+		} else if s[n] == '-' {
+			if l == 0 {
+				ind = n
+				l++
+			} else {
+				break
+			}
+		} else {
+			if l == 0 && s[n] == '.' {
+				if n+1 < len(s) && unicode.IsDigit(rune(s[n+1])) {
+					return "0", true
+				}
+
+				break
+			}
+
+			if l > 0 {
+				break
+			}
+		}
+	}
+
+	if l == 0 {
+		return "", false
+	}
+
+	return s[ind : ind+l], true
+}
+
+func firstFloatFromString(s string) (string, bool) { //nolint
+	c, ind, l := 0, 0, 0
+
+	for n := 0; n < len(s); n++ {
+		if unicode.IsDigit(rune(s[n])) {
+			if l == 0 {
+				ind = n
+			}
+
+			l++
+		} else if s[n] == '-' {
+			if l == 0 {
+				ind = n
+				l++
+			} else {
+				break
+			}
+		} else if s[n] == '.' {
+			if l == 0 {
+				ind = n
+			}
+
+			if c > 0 {
+				break
+			}
+
+			l++
+			c++
+		} else if s[n] == 'e' && l > 0 && n+1 < len(s) && s[n+1] == '+' {
+			l++
+		} else if s[n] == '+' && l > 0 && s[n-1] == 'e' {
+			if n+1 < len(s) && unicode.IsDigit(rune(s[n+1])) {
+				l++
+				continue
+			}
+
+			l--
+			break
+		} else {
+			if l > 0 {
+				break
+			}
+		}
+	}
+
+	if l == 0 || s[ind:ind+l] == "." {
+		return "", false
+	}
+
+	return s[ind : ind+l], true
+}

--- a/vendor/gopkg.in/h2non/gock.v1/.editorconfig
+++ b/vendor/gopkg.in/h2non/gock.v1/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/vendor/gopkg.in/h2non/gock.v1/.gitignore
+++ b/vendor/gopkg.in/h2non/gock.v1/.gitignore
@@ -1,0 +1,30 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+go.sum
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.idea/
+*.iml
+*.out
+*.tmp

--- a/vendor/gopkg.in/h2non/gock.v1/.travis.yml
+++ b/vendor/gopkg.in/h2non/gock.v1/.travis.yml
@@ -1,0 +1,26 @@
+language: go
+
+go:
+  - "1.11"
+  - "1.10"
+  - "stable"
+
+before_install:
+  - go get -u github.com/nbio/st
+  - go get -u github.com/codemodus/parth
+  - go get -u gopkg.in/h2non/gentleman.v1
+  - go get -u -v github.com/axw/gocov/gocov
+  - go get -u -v github.com/mattn/goveralls
+  - go get -v -u golang.org/x/lint/golint
+  - mkdir -p $GOPATH/src/gopkg.in/h2non/gock.v1
+  - cp -r . $GOPATH/src/gopkg.in/h2non/gock.v1
+
+script:
+  - diff -u <(echo -n) <(gofmt -s -d ./)
+  - diff -u <(echo -n) <(go vet ./...)
+  - diff -u <(echo -n) <(golint ./...)
+  - go test -v -race -covermode=atomic -coverprofile=coverage.out
+  - go test ./_examples/*/ -v -race
+
+after_success:
+  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/vendor/gopkg.in/h2non/gock.v1/History.md
+++ b/vendor/gopkg.in/h2non/gock.v1/History.md
@@ -1,0 +1,124 @@
+
+## v1.0.15 / 2019-07-03
+  
+  * NewMatcher() will now return objects that completely separate one another. (#55)
+  * add request Options (#49)
+  * fix typo: function -> func (#52)
+  * feat(docs): change note
+  * feat(docs): add net/http support
+  * Add Basic Auth (#47)
+  * Update LICENSE (#46)
+
+## v1.0.14 / 2019-01-31
+
+  * feat(version): bump to v1.0.14
+  * feat: add go.mod
+
+## v1.0.13 / 2019-01-30
+
+  * Add PathParam matcher (#42)
+
+## v1.0.12 / 2018-11-13
+
+  * Fix possible data race. (#41)
+
+## v1.0.11 / 2018-10-29
+
+  * Do not reset response body (#40)
+  * refactor(travis): remove unsupported versions for golint based on Go release policy support
+  * feat(gock): add gock.Observe to support inspection of the outgoing intercepted HTTP traffic (#38)
+
+## v1.0.10 / 2018-09-09
+
+  * Support multiple response headers with same name #35 (#36)
+
+## v1.0.9 / 2018-06-14
+
+  * fix(url-encoding) add exact match test in MatchPath (#34)
+  * fix(travis): use string notation for Go versions
+
+## v1.0.8 / 2018-02-28
+
+  * chore(LICENSE): update year ;)
+  * feat(docs): add additional tips and examples
+  * feat(gock): ignore already intercepted http.Client
+
+## v1.0.7 / 2017-12-21
+
+  * Make MatchHost case insensitive. (#31)
+  * refactor(docs): remove codesponsor :(
+  * add example when request reply with error (#28)
+  * feat(docs): add sponsor ad
+  * Add example networking partially enabled (#23)
+
+## v1.0.6 / 2017-07-27
+
+  * fix(#23): mock transport deadlock
+
+## v1.0.5 / 2017-07-26
+
+  * feat(#25, #24): use content type only if missing while matching JSON/XML
+  * feat(#24): add CleanUnmatchedRequests() and OffAll() public functions
+  * feat(version): bump to v1.0.5
+  * fix(store): use proper indent style
+  * fix(mutex): use different mutex for store
+  * feat(travis): add Go 1.8 CI support
+
+## v1.0.4 / 2017-02-14
+
+  * Update README to include most up to date version (#17)
+  * Update MatchBody() to compare if key + value pairs of JSON match regardless of order they are in. (#16)
+  * feat(examples): add new example for unmatch case
+  * refactor(docs): add pook reference
+
+## 1.0.3 / 14-11-2016
+
+- feat(#13): adds `GetUnmatchedRequests()` and `HasUnmatchedRequests()` API functions.
+
+## 1.0.2 / 10-11-2016
+
+- fix(#11): adds `Compression()` method for output HTTP traffic body compression processing and matching.
+
+## 1.0.1 / 07-09-2016
+
+- fix(#9): missing URL query param matcher.
+
+## 1.0.0 / 19-04-2016
+
+- feat(version): first major version release.
+
+## 0.1.6 / 19-04-2016
+
+- fix(#7): if error configured, RoundTripper should reply with `nil` response.
+
+## 0.1.5 / 09-04-2016
+
+- feat(#5): support `ReplyFunc` for convenience.
+
+## 0.1.4 / 16-03-2016
+
+- feat(api): add `IsDone()` method.
+- fix(responder): return mock error if present.
+- feat(#4): support define request/response body from file disk.
+
+## 0.1.3 / 09-03-2016
+
+- feat(matcher): add content type matcher helper method supporting aliases.
+- feat(interceptor): add function to restore HTTP client transport.
+- feat(matcher): add URL scheme matcher function.
+- fix(request): ignore base slash path.
+- feat(api): add Off() method for easier restore and clean up.
+- feat(store): add public API for pending mocks.
+
+## 0.1.2 / 04-03-2016
+
+- fix(matcher): body matchers no used by default.
+- feat(matcher): add matcher factories for multiple cases.
+
+## 0.1.1 / 04-03-2016
+
+- fix(params): persist query params accordingly.
+
+## 0.1.0 / 02-03-2016
+
+- First release.

--- a/vendor/gopkg.in/h2non/gock.v1/LICENSE
+++ b/vendor/gopkg.in/h2non/gock.v1/LICENSE
@@ -1,0 +1,24 @@
+The MIT License
+
+Copyright (c) 2016-2019 Tomas Aparicio
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/gopkg.in/h2non/gock.v1/README.md
+++ b/vendor/gopkg.in/h2non/gock.v1/README.md
@@ -1,0 +1,341 @@
+# gock [![Build Status](https://travis-ci.org/h2non/gock.svg?branch=master)](https://travis-ci.org/h2non/gock) [![GitHub release](https://img.shields.io/badge/version-v1.0-orange.svg?style=flat)](https://github.com/h2non/gock/releases) [![GoDoc](https://godoc.org/github.com/h2non/gock?status.svg)](https://godoc.org/github.com/h2non/gock) [![Coverage Status](https://coveralls.io/repos/github/h2non/gock/badge.svg?branch=master)](https://coveralls.io/github/h2non/gock?branch=master) [![Go Report Card](https://img.shields.io/badge/go_report-A+-brightgreen.svg)](https://goreportcard.com/report/github.com/h2non/gock) [![license](https://img.shields.io/badge/license-MIT-blue.svg)]()
+
+Versatile HTTP mocking made easy in [Go](https://golang.org) for `net/http` stdlib package.
+
+Heavily inspired by [nock](https://github.com/node-nock/nock).
+There is also its Python port, [pook](https://github.com/h2non/pook).
+
+To get started, take a look to the [examples](#examples).
+
+## Features
+
+- Simple, expressive, fluent API.
+- Semantic API DSL for declarative HTTP mock declarations.
+- Built-in helpers for easy JSON/XML mocking.
+- Supports persistent and volatile TTL-limited mocks.
+- Full regular expressions capable HTTP request mock matching.
+- Designed for both testing and runtime scenarios.
+- Match request by method, URL params, headers and bodies.
+- Extensible and pluggable HTTP matching rules.
+- Ability to switch between mock and real networking modes.
+- Ability to filter/map HTTP requests for accurate mock matching.
+- Supports map and filters to handle mocks easily.
+- Wide compatible HTTP interceptor using `http.RoundTripper` interface.
+- Works with any `net/http` compatible client, such as [gentleman](https://github.com/h2non/gentleman).
+- Network delay simulation (beta).
+- Extensible and hackable API.
+- Dependency free.
+
+## Installation
+
+```bash
+go get -u gopkg.in/h2non/gock.v1
+```
+
+## API
+
+See [godoc reference](https://godoc.org/github.com/h2non/gock) for detailed API documentation.
+
+## How it mocks
+
+1. Intercepts any HTTP outgoing request via `http.DefaultTransport` or custom `http.Transport` used by any `http.Client`.
+2. Matches outgoing HTTP requests against a pool of defined HTTP mock expectations in FIFO declaration order.
+3. If at least one mock matches, it will be used in order to compose the mock HTTP response.
+4. If no mock can be matched, it will resolve the request with an error, unless real networking mode is enable, in which case a real HTTP request will be performed.
+
+## Tips
+
+#### Testing
+
+Declare your mocks before you start declaring the concrete test logic:
+
+```go
+func TestFoo(t *testing.T) {
+  defer gock.Off() // Flush pending mocks after test execution
+
+  gock.New("http://server.com").
+    Get("/bar").
+    Reply(200).
+    JSON(map[string]string{"foo": "bar"})
+
+  // Your test code starts here...
+}
+```
+
+#### Race conditions
+
+If you're running concurrent code, be aware that your mocks are declared first to avoid unexpected
+race conditions while configuring `gock` or intercepting custom HTTP clients.
+
+`gock` is not fully thread-safe, but sensible parts are.
+Any help making `gock` more reliable in this sense is appreciated.
+
+#### Define complex mocks first
+
+If you're mocking a bunch of mocks in the same test suite, it's recommended to define the more
+concrete mocks first, and then the generic ones.
+
+This approach usually avoids matching unexpected generic mocks (e.g: specific header, body payload...) instead of the generic ones that performs less complex matches.
+
+#### Disable `gock` traffic interception once done
+
+In other to minimize potential side effects within your test code, it's a good practice
+disabling `gock` once you are done with your HTTP testing logic.
+
+A Go idiomatic approach for doing this can be using it in a `defer` statement, such as:
+
+```go
+func TestGock (t *testing.T) {
+	defer gock.Off()
+
+	// ... my test code goes here
+}
+```
+
+#### Intercept an `http.Client` just once
+
+You don't need to intercept multiple times the same `http.Client` instance.
+
+Just call `gock.InterceptClient(client)` once, typically at the beginning of your test scenarios.
+
+#### Restore an `http.Client` after interception
+
+**NOTE**: this is not required is you are using `http.DefaultClient` or `http.DefaultTransport`.
+
+As a good testing pattern, you should call `gock.RestoreClient(client)` after running your test scenario, typically as after clean up hook.
+
+You can also use a `defer` statement for doing it, as you do with `gock.Off()`, such as:
+
+```go
+func TestGock (t *testing.T) {
+	defer gock.Off()
+	defer gock.RestoreClient(client)
+
+	// ... my test code goes here
+}
+```
+
+## Examples
+
+See [examples](https://github.com/h2non/gock/tree/master/_examples) directory for more featured use cases.
+
+#### Simple mocking via tests
+
+```go
+package test
+
+import (
+  "github.com/nbio/st"
+  "gopkg.in/h2non/gock.v1"
+  "io/ioutil"
+  "net/http"
+  "testing"
+)
+
+func TestSimple(t *testing.T) {
+  defer gock.Off()
+
+  gock.New("http://foo.com").
+    Get("/bar").
+    Reply(200).
+    JSON(map[string]string{"foo": "bar"})
+
+  res, err := http.Get("http://foo.com/bar")
+  st.Expect(t, err, nil)
+  st.Expect(t, res.StatusCode, 200)
+
+  body, _ := ioutil.ReadAll(res.Body)
+  st.Expect(t, string(body)[:13], `{"foo":"bar"}`)
+
+  // Verify that we don't have pending mocks
+  st.Expect(t, gock.IsDone(), true)
+}
+```
+
+#### Request headers matching
+
+```go
+package test
+
+import (
+  "github.com/nbio/st"
+  "gopkg.in/h2non/gock.v1"
+  "io/ioutil"
+  "net/http"
+  "testing"
+)
+
+func TestMatchHeaders(t *testing.T) {
+  defer gock.Off()
+
+  gock.New("http://foo.com").
+    MatchHeader("Authorization", "^foo bar$").
+    MatchHeader("API", "1.[0-9]+").
+    HeaderPresent("Accept").
+    Reply(200).
+    BodyString("foo foo")
+
+  req, err := http.NewRequest("GET", "http://foo.com", nil)
+  req.Header.Set("Authorization", "foo bar")
+  req.Header.Set("API", "1.0")
+  req.Header.Set("Accept", "text/plain")
+
+  res, err := (&http.Client{}).Do(req)
+  st.Expect(t, err, nil)
+  st.Expect(t, res.StatusCode, 200)
+  body, _ := ioutil.ReadAll(res.Body)
+  st.Expect(t, string(body), "foo foo")
+
+  // Verify that we don't have pending mocks
+  st.Expect(t, gock.IsDone(), true)
+}
+```
+
+#### JSON body matching and response
+
+```go
+package test
+
+import (
+  "bytes"
+  "github.com/nbio/st"
+  "gopkg.in/h2non/gock.v1"
+  "io/ioutil"
+  "net/http"
+  "testing"
+)
+
+func TestMockSimple(t *testing.T) {
+  defer gock.Off()
+
+  gock.New("http://foo.com").
+    Post("/bar").
+    MatchType("json").
+    JSON(map[string]string{"foo": "bar"}).
+    Reply(201).
+    JSON(map[string]string{"bar": "foo"})
+
+  body := bytes.NewBuffer([]byte(`{"foo":"bar"}`))
+  res, err := http.Post("http://foo.com/bar", "application/json", body)
+  st.Expect(t, err, nil)
+  st.Expect(t, res.StatusCode, 201)
+
+  resBody, _ := ioutil.ReadAll(res.Body)
+  st.Expect(t, string(resBody)[:13], `{"bar":"foo"}`)
+
+  // Verify that we don't have pending mocks
+  st.Expect(t, gock.IsDone(), true)
+}
+```
+
+#### Mocking a custom http.Client and http.RoundTripper
+
+```go
+package test
+
+import (
+  "github.com/nbio/st"
+  "gopkg.in/h2non/gock.v1"
+  "io/ioutil"
+  "net/http"
+  "testing"
+)
+
+func TestClient(t *testing.T) {
+  defer gock.Off()
+
+  gock.New("http://foo.com").
+    Reply(200).
+    BodyString("foo foo")
+
+  req, err := http.NewRequest("GET", "http://foo.com", nil)
+  client := &http.Client{Transport: &http.Transport{}}
+  gock.InterceptClient(client)
+
+  res, err := client.Do(req)
+  st.Expect(t, err, nil)
+  st.Expect(t, res.StatusCode, 200)
+  body, _ := ioutil.ReadAll(res.Body)
+  st.Expect(t, string(body), "foo foo")
+
+  // Verify that we don't have pending mocks
+  st.Expect(t, gock.IsDone(), true)
+}
+```
+
+#### Enable real networking
+
+```go
+package main
+
+import (
+  "fmt"
+  "gopkg.in/h2non/gock.v1"
+  "io/ioutil"
+  "net/http"
+)
+
+func main() {
+  defer gock.Off()
+  defer gock.DisableNetworking()
+
+  gock.EnableNetworking()
+  gock.New("http://httpbin.org").
+    Get("/get").
+    Reply(201).
+    SetHeader("Server", "gock")
+
+  res, err := http.Get("http://httpbin.org/get")
+  if err != nil {
+    fmt.Errorf("Error: %s", err)
+  }
+
+  // The response status comes from the mock
+  fmt.Printf("Status: %d\n", res.StatusCode)
+  // The server header comes from mock as well
+  fmt.Printf("Server header: %s\n", res.Header.Get("Server"))
+  // Response body is the original
+  body, _ := ioutil.ReadAll(res.Body)
+  fmt.Printf("Body: %s", string(body))
+
+  // Verify that we don't have pending mocks
+  st.Expect(t, gock.IsDone(), true)
+}
+```
+
+#### Debug intercepted http requests
+
+```go
+package main
+
+import (
+	"bytes"
+	"gopkg.in/h2non/gock.v1"
+	"net/http"
+)
+
+func main() {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	gock.New("http://foo.com").
+		Post("/bar").
+		MatchType("json").
+		JSON(map[string]string{"foo": "bar"}).
+		Reply(200)
+
+	body := bytes.NewBuffer([]byte(`{"foo":"bar"}`))
+	http.Post("http://foo.com/bar", "application/json", body)
+}
+
+```
+
+## Hacking it!
+
+You can easily hack `gock` defining custom matcher functions with own matching rules.
+
+See [add matcher functions](https://github.com/h2non/gock/blob/master/_examples/add_matchers/matchers.go) and [custom matching layer](https://github.com/h2non/gock/blob/master/_examples/custom_matcher/matcher.go) examples for further details.
+
+## License
+
+MIT - Tomas Aparicio

--- a/vendor/gopkg.in/h2non/gock.v1/go.mod
+++ b/vendor/gopkg.in/h2non/gock.v1/go.mod
@@ -1,0 +1,6 @@
+module gopkg.in/h2non/gock.v1
+
+require (
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542
+	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32
+)

--- a/vendor/gopkg.in/h2non/gock.v1/gock.go
+++ b/vendor/gopkg.in/h2non/gock.v1/gock.go
@@ -1,0 +1,176 @@
+package gock
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"regexp"
+	"sync"
+)
+
+// mutex is used interally for locking thread-sensitive functions.
+var mutex = &sync.Mutex{}
+
+// config global singleton store.
+var config = struct {
+	Networking        bool
+	NetworkingFilters []FilterRequestFunc
+	Observer          ObserverFunc
+}{}
+
+// ObserverFunc is implemented by users to inspect the outgoing intercepted HTTP traffic
+type ObserverFunc func(*http.Request, Mock)
+
+// DumpRequest is a default implementation of ObserverFunc that dumps
+// the HTTP/1.x wire representation of the http request
+var DumpRequest ObserverFunc = func(request *http.Request, mock Mock) {
+	bytes, _ := httputil.DumpRequestOut(request, true)
+	fmt.Println(string(bytes))
+	fmt.Printf("\nMatches: %v\n---\n", mock != nil)
+}
+
+// track unmatched requests so they can be tested for
+var unmatchedRequests = []*http.Request{}
+
+// New creates and registers a new HTTP mock with
+// default settings and returns the Request DSL for HTTP mock
+// definition and set up.
+func New(uri string) *Request {
+	Intercept()
+
+	res := NewResponse()
+	req := NewRequest()
+	req.URLStruct, res.Error = url.Parse(normalizeURI(uri))
+
+	// Create the new mock expectation
+	exp := NewMock(req, res)
+	Register(exp)
+
+	return req
+}
+
+// Intercepting returns true if gock is currently able to intercept.
+func Intercepting() bool {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return http.DefaultTransport == DefaultTransport
+}
+
+// Intercept enables HTTP traffic interception via http.DefaultTransport.
+// If you are using a custom HTTP transport, you have to use `gock.Transport()`
+func Intercept() {
+	if !Intercepting() {
+		http.DefaultTransport = DefaultTransport
+	}
+}
+
+// InterceptClient allows the developer to intercept HTTP traffic using
+// a custom http.Client who uses a non default http.Transport/http.RoundTripper implementation.
+func InterceptClient(cli *http.Client) {
+	_, ok := cli.Transport.(*Transport)
+	if ok {
+		return // if transport already intercepted, just ignore it
+	}
+	trans := NewTransport()
+	trans.Transport = cli.Transport
+	cli.Transport = trans
+}
+
+// RestoreClient allows the developer to disable and restore the
+// original transport in the given http.Client.
+func RestoreClient(cli *http.Client) {
+	trans, ok := cli.Transport.(*Transport)
+	if !ok {
+		return
+	}
+	cli.Transport = trans.Transport
+}
+
+// Disable disables HTTP traffic interception by gock.
+func Disable() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	http.DefaultTransport = NativeTransport
+}
+
+// Off disables the default HTTP interceptors and removes
+// all the registered mocks, even if they has not been intercepted yet.
+func Off() {
+	Flush()
+	Disable()
+}
+
+// OffAll is like `Off()`, but it also removes the unmatched requests registry.
+func OffAll() {
+	Flush()
+	Disable()
+	CleanUnmatchedRequest()
+}
+
+// Observe provides a hook to support inspection of the request and matched mock
+func Observe(fn ObserverFunc) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	config.Observer = fn
+}
+
+// EnableNetworking enables real HTTP networking
+func EnableNetworking() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	config.Networking = true
+}
+
+// DisableNetworking disables real HTTP networking
+func DisableNetworking() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	config.Networking = false
+}
+
+// NetworkingFilter determines if an http.Request should be triggered or not.
+func NetworkingFilter(fn FilterRequestFunc) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	config.NetworkingFilters = append(config.NetworkingFilters, fn)
+}
+
+// DisableNetworkingFilters disables registered networking filters.
+func DisableNetworkingFilters() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	config.NetworkingFilters = []FilterRequestFunc{}
+}
+
+// GetUnmatchedRequests returns all requests that have been received but haven't matched any mock
+func GetUnmatchedRequests() []*http.Request {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return unmatchedRequests
+}
+
+// HasUnmatchedRequest returns true if gock has received any requests that didn't match a mock
+func HasUnmatchedRequest() bool {
+	return len(GetUnmatchedRequests()) > 0
+}
+
+// CleanUnmatchedRequest cleans the unmatched requests internal registry.
+func CleanUnmatchedRequest() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	unmatchedRequests = []*http.Request{}
+}
+
+func trackUnmatchedRequest(req *http.Request) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	unmatchedRequests = append(unmatchedRequests, req)
+}
+
+func normalizeURI(uri string) string {
+	if ok, _ := regexp.MatchString("^http[s]?", uri); !ok {
+		return "http://" + uri
+	}
+	return uri
+}

--- a/vendor/gopkg.in/h2non/gock.v1/matcher.go
+++ b/vendor/gopkg.in/h2non/gock.v1/matcher.go
@@ -1,0 +1,135 @@
+package gock
+
+import "net/http"
+
+// MatchersHeader exposes an slice of HTTP header specific mock matchers.
+var MatchersHeader = []MatchFunc{
+	MatchMethod,
+	MatchScheme,
+	MatchHost,
+	MatchPath,
+	MatchHeaders,
+	MatchQueryParams,
+	MatchPathParams,
+}
+
+// MatchersBody exposes an slice of HTTP body specific built-in mock matchers.
+var MatchersBody = []MatchFunc{
+	MatchBody,
+}
+
+// Matchers stores all the built-in mock matchers.
+var Matchers = append(MatchersHeader, MatchersBody...)
+
+// DefaultMatcher stores the default Matcher instance used to match mocks.
+var DefaultMatcher = NewMatcher()
+
+// MatchFunc represents the required function
+// interface implemented by matchers.
+type MatchFunc func(*http.Request, *Request) (bool, error)
+
+// Matcher represents the required interface implemented by mock matchers.
+type Matcher interface {
+	// Get returns a slice of registered function matchers.
+	Get() []MatchFunc
+
+	// Add adds a new matcher function.
+	Add(MatchFunc)
+
+	// Set sets the matchers functions stack.
+	Set([]MatchFunc)
+
+	// Flush flushes the current matchers function stack.
+	Flush()
+
+	// Match matches the given http.Request with a mock Request.
+	Match(*http.Request, *Request) (bool, error)
+}
+
+// MockMatcher implements a mock matcher
+type MockMatcher struct {
+	Matchers []MatchFunc
+}
+
+// NewMatcher creates a new mock matcher
+// using the default matcher functions.
+func NewMatcher() *MockMatcher {
+	m := NewEmptyMatcher()
+	for _, matchFn := range Matchers {
+		m.Add(matchFn)
+	}
+	return m
+}
+
+// NewBasicMatcher creates a new matcher with header only mock matchers.
+func NewBasicMatcher() *MockMatcher {
+	m := NewEmptyMatcher()
+	for _, matchFn := range MatchersHeader {
+		m.Add(matchFn)
+	}
+	return m
+}
+
+// NewEmptyMatcher creates a new empty matcher without default matchers.
+func NewEmptyMatcher() *MockMatcher {
+	return &MockMatcher{Matchers: []MatchFunc{}}
+}
+
+// Get returns a slice of registered function matchers.
+func (m *MockMatcher) Get() []MatchFunc {
+	return m.Matchers
+}
+
+// Add adds a new function matcher.
+func (m *MockMatcher) Add(fn MatchFunc) {
+	m.Matchers = append(m.Matchers, fn)
+}
+
+// Set sets a new stack of matchers functions.
+func (m *MockMatcher) Set(stack []MatchFunc) {
+	m.Matchers = stack
+}
+
+// Flush flushes the current matcher
+func (m *MockMatcher) Flush() {
+	m.Matchers = []MatchFunc{}
+}
+
+// Clone returns a separate MockMatcher instance that has a copy of the same MatcherFuncs
+func (m *MockMatcher) Clone() *MockMatcher {
+	m2 := NewEmptyMatcher()
+	for _, mFn := range m.Get() {
+		m2.Add(mFn)
+	}
+	return m2
+}
+
+// Match matches the given http.Request with a mock request
+// returning true in case that the request matches, otherwise false.
+func (m *MockMatcher) Match(req *http.Request, ereq *Request) (bool, error) {
+	for _, matcher := range m.Matchers {
+		matches, err := matcher(req, ereq)
+		if err != nil {
+			return false, err
+		}
+		if !matches {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// MatchMock is a helper function that matches the given http.Request
+// in the list of registered mocks, returning it if matches or error if it fails.
+func MatchMock(req *http.Request) (Mock, error) {
+	for _, mock := range GetAll() {
+		matches, err := mock.Match(req)
+		if err != nil {
+			return nil, err
+		}
+		if matches {
+			return mock, nil
+		}
+	}
+	return nil, nil
+}

--- a/vendor/gopkg.in/h2non/gock.v1/matchers.go
+++ b/vendor/gopkg.in/h2non/gock.v1/matchers.go
@@ -1,0 +1,256 @@
+package gock
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/h2non/parth"
+)
+
+// EOL represents the end of line character.
+const EOL = 0xa
+
+// BodyTypes stores the supported MIME body types for matching.
+// Currently only text-based types.
+var BodyTypes = []string{
+	"text/html",
+	"text/plain",
+	"application/json",
+	"application/xml",
+	"multipart/form-data",
+	"application/x-www-form-urlencoded",
+}
+
+// BodyTypeAliases stores a generic MIME type by alias.
+var BodyTypeAliases = map[string]string{
+	"html": "text/html",
+	"text": "text/plain",
+	"json": "application/json",
+	"xml":  "application/xml",
+	"form": "multipart/form-data",
+	"url":  "application/x-www-form-urlencoded",
+}
+
+// CompressionSchemes stores the supported Content-Encoding types for decompression.
+var CompressionSchemes = []string{
+	"gzip",
+}
+
+// MatchMethod matches the HTTP method of the given request.
+func MatchMethod(req *http.Request, ereq *Request) (bool, error) {
+	return ereq.Method == "" || req.Method == ereq.Method, nil
+}
+
+// MatchScheme matches the request URL protocol scheme.
+func MatchScheme(req *http.Request, ereq *Request) (bool, error) {
+	return ereq.URLStruct.Scheme == "" || req.URL.Scheme == "" || ereq.URLStruct.Scheme == req.URL.Scheme, nil
+}
+
+// MatchHost matches the HTTP host header field of the given request.
+func MatchHost(req *http.Request, ereq *Request) (bool, error) {
+	url := ereq.URLStruct
+	if strings.EqualFold(url.Host, req.URL.Host) {
+		return true, nil
+	}
+	if !ereq.Options.DisableRegexpHost {
+		return regexp.MatchString(url.Host, req.URL.Host)
+	}
+	return false, nil
+}
+
+// MatchPath matches the HTTP URL path of the given request.
+func MatchPath(req *http.Request, ereq *Request) (bool, error) {
+	if req.URL.Path == ereq.URLStruct.Path {
+		return true, nil
+	}
+	return regexp.MatchString(ereq.URLStruct.Path, req.URL.Path)
+}
+
+// MatchHeaders matches the headers fields of the given request.
+func MatchHeaders(req *http.Request, ereq *Request) (bool, error) {
+	for key, value := range ereq.Header {
+		var err error
+		var match bool
+
+		for _, field := range req.Header[key] {
+			match, err = regexp.MatchString(value[0], field)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				break
+			}
+		}
+
+		if !match {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// MatchQueryParams matches the URL query params fields of the given request.
+func MatchQueryParams(req *http.Request, ereq *Request) (bool, error) {
+	for key, value := range ereq.URLStruct.Query() {
+		var err error
+		var match bool
+
+		for _, field := range req.URL.Query()[key] {
+			match, err = regexp.MatchString(value[0], field)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				break
+			}
+		}
+
+		if !match {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// MatchPathParams matches the URL path parameters of the given request.
+func MatchPathParams(req *http.Request, ereq *Request) (bool, error) {
+	for key, value := range ereq.PathParams {
+		var s string
+
+		if err := parth.Sequent(req.URL.Path, key, &s); err != nil {
+			return false, nil
+		}
+
+		if s != value {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// MatchBody tries to match the request body.
+// TODO: not too smart now, needs several improvements.
+func MatchBody(req *http.Request, ereq *Request) (bool, error) {
+	// If match body is empty, just continue
+	if req.Method == "HEAD" || len(ereq.BodyBuffer) == 0 {
+		return true, nil
+	}
+
+	// Only can match certain MIME body types
+	if !supportedType(req) {
+		return false, nil
+	}
+
+	// Can only match certain compression schemes
+	if !supportedCompressionScheme(req) {
+		return false, nil
+	}
+
+	// Create a reader for the body depending on compression type
+	bodyReader := req.Body
+	if ereq.CompressionScheme != "" {
+		if ereq.CompressionScheme != req.Header.Get("Content-Encoding") {
+			return false, nil
+		}
+		compressedBodyReader, err := compressionReader(req.Body, ereq.CompressionScheme)
+		if err != nil {
+			return false, err
+		}
+		bodyReader = compressedBodyReader
+	}
+
+	// Read the whole request body
+	body, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		return false, err
+	}
+
+	// Restore body reader stream
+	req.Body = createReadCloser(body)
+
+	// If empty, ignore the match
+	if len(body) == 0 && len(ereq.BodyBuffer) != 0 {
+		return false, nil
+	}
+
+	// Match body by atomic string comparison
+	bodyStr := castToString(body)
+	matchStr := castToString(ereq.BodyBuffer)
+	if bodyStr == matchStr {
+		return true, nil
+	}
+
+	// Match request body by regexp
+	match, _ := regexp.MatchString(matchStr, bodyStr)
+	if match == true {
+		return true, nil
+	}
+
+	// todo - add conditional do only perform the conversion of body bytes
+	// representation of JSON to a map and then compare them for equality.
+
+	// Check if the key + value pairs match
+	var bodyMap map[string]interface{}
+	var matchMap map[string]interface{}
+
+	// Ensure that both byte bodies that that should be JSON can be converted to maps.
+	umErr := json.Unmarshal(body, &bodyMap)
+	umErr2 := json.Unmarshal(ereq.BodyBuffer, &matchMap)
+	if umErr == nil && umErr2 == nil && reflect.DeepEqual(bodyMap, matchMap) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func supportedType(req *http.Request) bool {
+	mime := req.Header.Get("Content-Type")
+	if mime == "" {
+		return true
+	}
+
+	for _, kind := range BodyTypes {
+		if match, _ := regexp.MatchString(kind, mime); match {
+			return true
+		}
+	}
+	return false
+}
+
+func supportedCompressionScheme(req *http.Request) bool {
+	encoding := req.Header.Get("Content-Encoding")
+	if encoding == "" {
+		return true
+	}
+
+	for _, kind := range CompressionSchemes {
+		if match, _ := regexp.MatchString(kind, encoding); match {
+			return true
+		}
+	}
+	return false
+}
+
+func castToString(buf []byte) string {
+	str := string(buf)
+	tail := len(str) - 1
+	if str[tail] == EOL {
+		str = str[:tail]
+	}
+	return str
+}
+
+func compressionReader(r io.ReadCloser, scheme string) (io.ReadCloser, error) {
+	switch scheme {
+	case "gzip":
+		return gzip.NewReader(r)
+	default:
+		return r, nil
+	}
+}

--- a/vendor/gopkg.in/h2non/gock.v1/mock.go
+++ b/vendor/gopkg.in/h2non/gock.v1/mock.go
@@ -1,0 +1,146 @@
+package gock
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Mock represents the required interface that must
+// be implemented by HTTP mock instances.
+type Mock interface {
+	// Disable disables the current mock manually.
+	Disable()
+
+	// Done returns true if the current mock is disabled.
+	Done() bool
+
+	// Request returns the mock Request instance.
+	Request() *Request
+
+	// Response returns the mock Response instance.
+	Response() *Response
+
+	// Match matches the given http.Request with the current mock.
+	Match(*http.Request) (bool, error)
+
+	// AddMatcher adds a new matcher function.
+	AddMatcher(MatchFunc)
+
+	// SetMatcher uses a new matcher implementation.
+	SetMatcher(Matcher)
+}
+
+// Mocker implements a Mock capable interface providing
+// a default mock configuration used internally to store mocks.
+type Mocker struct {
+	// disabled stores if the current mock is disabled.
+	disabled bool
+
+	// mutex stores the mock mutex for thread safity.
+	mutex sync.Mutex
+
+	// matcher stores a Matcher capable instance to match the given http.Request.
+	matcher Matcher
+
+	// request stores the mock Request to match.
+	request *Request
+
+	// response stores the mock Response to use in case of match.
+	response *Response
+}
+
+// NewMock creates a new HTTP mock based on the given request and response instances.
+// It's mostly used internally.
+func NewMock(req *Request, res *Response) *Mocker {
+	mock := &Mocker{
+		request:  req,
+		response: res,
+		matcher:  DefaultMatcher.Clone(),
+	}
+	res.Mock = mock
+	req.Mock = mock
+	req.Response = res
+	return mock
+}
+
+// Disable disables the current mock manually.
+func (m *Mocker) Disable() {
+	m.disabled = true
+}
+
+// Done returns true in case that the current mock
+// instance is disabled and therefore must be removed.
+func (m *Mocker) Done() bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.disabled || (!m.request.Persisted && m.request.Counter == 0)
+}
+
+// Request returns the Request instance
+// configured for the current HTTP mock.
+func (m *Mocker) Request() *Request {
+	return m.request
+}
+
+// Response returns the Response instance
+// configured for the current HTTP mock.
+func (m *Mocker) Response() *Response {
+	return m.response
+}
+
+// Match matches the given http.Request with the current Request
+// mock expectation, returning true if matches.
+func (m *Mocker) Match(req *http.Request) (bool, error) {
+	if m.disabled {
+		return false, nil
+	}
+
+	// Filter
+	for _, filter := range m.request.Filters {
+		if !filter(req) {
+			return false, nil
+		}
+	}
+
+	// Map
+	for _, mapper := range m.request.Mappers {
+		if treq := mapper(req); treq != nil {
+			req = treq
+		}
+	}
+
+	// Match
+	matches, err := m.matcher.Match(req, m.request)
+	if matches {
+		m.decrement()
+	}
+
+	return matches, err
+}
+
+// SetMatcher sets a new matcher implementation
+// for the current mock expectation.
+func (m *Mocker) SetMatcher(matcher Matcher) {
+	m.matcher = matcher
+}
+
+// AddMatcher adds a new matcher function
+// for the current mock expectation.
+func (m *Mocker) AddMatcher(fn MatchFunc) {
+	m.matcher.Add(fn)
+}
+
+// decrement decrements the current mock Request counter.
+func (m *Mocker) decrement() {
+	if m.request.Persisted {
+		return
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.request.Counter--
+	if m.request.Counter == 0 {
+		m.disabled = true
+	}
+}

--- a/vendor/gopkg.in/h2non/gock.v1/options.go
+++ b/vendor/gopkg.in/h2non/gock.v1/options.go
@@ -1,0 +1,8 @@
+package gock
+
+// Options represents customized option for gock
+type Options struct {
+	// DisableRegexpHost stores if the host is only a plain string rather than regular expression,
+	// if DisableRegexpHost is true, host sets in gock.New(...) will be treated as plain string
+	DisableRegexpHost bool
+}

--- a/vendor/gopkg.in/h2non/gock.v1/request.go
+++ b/vendor/gopkg.in/h2non/gock.v1/request.go
@@ -1,0 +1,325 @@
+package gock
+
+import (
+	"encoding/base64"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// MapRequestFunc represents the required function interface for request mappers.
+type MapRequestFunc func(*http.Request) *http.Request
+
+// FilterRequestFunc represents the required function interface for request filters.
+type FilterRequestFunc func(*http.Request) bool
+
+// Request represents the high-level HTTP request used to store
+// request fields used to match intercepted requests.
+type Request struct {
+	// Mock stores the parent mock reference for the current request mock used for method delegation.
+	Mock Mock
+
+	// Response stores the current Response instance for the current matches Request.
+	Response *Response
+
+	// Error stores the latest mock request configuration error.
+	Error error
+
+	// Counter stores the pending times that the current mock should be active.
+	Counter int
+
+	// Persisted stores if the current mock should be always active.
+	Persisted bool
+
+	// Options stores options for current Request.
+	Options Options
+
+	// URLStruct stores the parsed URL as *url.URL struct.
+	URLStruct *url.URL
+
+	// Method stores the Request HTTP method to match.
+	Method string
+
+	// CompressionScheme stores the Request Compression scheme to match and use for decompression.
+	CompressionScheme string
+
+	// Header stores the HTTP header fields to match.
+	Header http.Header
+
+	// Cookies stores the Request HTTP cookies values to match.
+	Cookies []*http.Cookie
+
+	// PathParams stores the path parameters to match.
+	PathParams map[string]string
+
+	// BodyBuffer stores the body data to match.
+	BodyBuffer []byte
+
+	// Mappers stores the request functions mappers used for matching.
+	Mappers []MapRequestFunc
+
+	// Filters stores the request functions filters used for matching.
+	Filters []FilterRequestFunc
+}
+
+// NewRequest creates a new Request instance.
+func NewRequest() *Request {
+	return &Request{
+		Counter:    1,
+		URLStruct:  &url.URL{},
+		Header:     make(http.Header),
+		PathParams: make(map[string]string),
+	}
+}
+
+// URL defines the mock URL to match.
+func (r *Request) URL(uri string) *Request {
+	r.URLStruct, r.Error = url.Parse(uri)
+	return r
+}
+
+// SetURL defines the url.URL struct to be used for matching.
+func (r *Request) SetURL(u *url.URL) *Request {
+	r.URLStruct = u
+	return r
+}
+
+// Path defines the mock URL path value to match.
+func (r *Request) Path(path string) *Request {
+	r.URLStruct.Path = path
+	return r
+}
+
+// Get specifies the GET method and the given URL path to match.
+func (r *Request) Get(path string) *Request {
+	return r.method("GET", path)
+}
+
+// Post specifies the POST method and the given URL path to match.
+func (r *Request) Post(path string) *Request {
+	return r.method("POST", path)
+}
+
+// Put specifies the PUT method and the given URL path to match.
+func (r *Request) Put(path string) *Request {
+	return r.method("PUT", path)
+}
+
+// Delete specifies the DELETE method and the given URL path to match.
+func (r *Request) Delete(path string) *Request {
+	return r.method("DELETE", path)
+}
+
+// Patch specifies the PATCH method and the given URL path to match.
+func (r *Request) Patch(path string) *Request {
+	return r.method("PATCH", path)
+}
+
+// Head specifies the HEAD method and the given URL path to match.
+func (r *Request) Head(path string) *Request {
+	return r.method("HEAD", path)
+}
+
+// method is a DRY shortcut used to declare the expected HTTP method and URL path.
+func (r *Request) method(method, path string) *Request {
+	if path != "/" {
+		r.URLStruct.Path = path
+	}
+	r.Method = strings.ToUpper(method)
+	return r
+}
+
+// Body defines the body data to match based on a io.Reader interface.
+func (r *Request) Body(body io.Reader) *Request {
+	r.BodyBuffer, r.Error = ioutil.ReadAll(body)
+	return r
+}
+
+// BodyString defines the body to match based on a given string.
+func (r *Request) BodyString(body string) *Request {
+	r.BodyBuffer = []byte(body)
+	return r
+}
+
+// File defines the body to match based on the given file path string.
+func (r *Request) File(path string) *Request {
+	r.BodyBuffer, r.Error = ioutil.ReadFile(path)
+	return r
+}
+
+// Compression defines the request compression scheme, and enables automatic body decompression.
+// Supports only the "gzip" scheme so far.
+func (r *Request) Compression(scheme string) *Request {
+	r.Header.Set("Content-Encoding", scheme)
+	r.CompressionScheme = scheme
+	return r
+}
+
+// JSON defines the JSON body to match based on a given structure.
+func (r *Request) JSON(data interface{}) *Request {
+	if r.Header.Get("Content-Type") == "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	r.BodyBuffer, r.Error = readAndDecode(data, "json")
+	return r
+}
+
+// XML defines the XML body to match based on a given structure.
+func (r *Request) XML(data interface{}) *Request {
+	if r.Header.Get("Content-Type") == "" {
+		r.Header.Set("Content-Type", "application/xml")
+	}
+	r.BodyBuffer, r.Error = readAndDecode(data, "xml")
+	return r
+}
+
+// MatchType defines the request Content-Type MIME header field.
+// Supports type alias. E.g: json, xml, form, text...
+func (r *Request) MatchType(kind string) *Request {
+	mime := BodyTypeAliases[kind]
+	if mime != "" {
+		kind = mime
+	}
+	r.Header.Set("Content-Type", kind)
+	return r
+}
+
+// BasicAuth defines a username and password for HTTP Basic Authentication
+func (r *Request) BasicAuth(username, password string) *Request {
+	r.Header.Set("Authorization", "Basic "+basicAuth(username, password))
+	return r
+}
+
+// MatchHeader defines a new key and value header to match.
+func (r *Request) MatchHeader(key, value string) *Request {
+	r.Header.Set(key, value)
+	return r
+}
+
+// HeaderPresent defines that a header field must be present in the request.
+func (r *Request) HeaderPresent(key string) *Request {
+	r.Header.Set(key, ".*")
+	return r
+}
+
+// MatchHeaders defines a map of key-value headers to match.
+func (r *Request) MatchHeaders(headers map[string]string) *Request {
+	for key, value := range headers {
+		r.Header.Set(key, value)
+	}
+	return r
+}
+
+// MatchParam defines a new key and value URL query param to match.
+func (r *Request) MatchParam(key, value string) *Request {
+	query := r.URLStruct.Query()
+	query.Set(key, value)
+	r.URLStruct.RawQuery = query.Encode()
+	return r
+}
+
+// MatchParams defines a map of URL query param key-value to match.
+func (r *Request) MatchParams(params map[string]string) *Request {
+	query := r.URLStruct.Query()
+	for key, value := range params {
+		query.Set(key, value)
+	}
+	r.URLStruct.RawQuery = query.Encode()
+	return r
+}
+
+// ParamPresent matches if the given query param key is present in the URL.
+func (r *Request) ParamPresent(key string) *Request {
+	r.MatchParam(key, ".*")
+	return r
+}
+
+// PathParam matches if a given path parameter key is present in the URL.
+//
+// The value is representative of the restful resource the key defines, e.g.
+//   // /users/123/name
+//   r.PathParam("users", "123")
+// would match.
+func (r *Request) PathParam(key, val string) *Request {
+	r.PathParams[key] = val
+
+	return r
+}
+
+// Persist defines the current HTTP mock as persistent and won't be removed after intercepting it.
+func (r *Request) Persist() *Request {
+	r.Persisted = true
+	return r
+}
+
+// WithOptions sets the options for the request.
+func (r *Request) WithOptions(options Options) *Request {
+	r.Options = options
+	return r
+}
+
+// Times defines the number of times that the current HTTP mock should remain active.
+func (r *Request) Times(num int) *Request {
+	r.Counter = num
+	return r
+}
+
+// AddMatcher adds a new matcher function to match the request.
+func (r *Request) AddMatcher(fn MatchFunc) *Request {
+	r.Mock.AddMatcher(fn)
+	return r
+}
+
+// SetMatcher sets a new matcher function to match the request.
+func (r *Request) SetMatcher(matcher Matcher) *Request {
+	r.Mock.SetMatcher(matcher)
+	return r
+}
+
+// Map adds a new request mapper function to map http.Request before the matching process.
+func (r *Request) Map(fn MapRequestFunc) *Request {
+	r.Mappers = append(r.Mappers, fn)
+	return r
+}
+
+// Filter filters a new request filter function to filter http.Request before the matching process.
+func (r *Request) Filter(fn FilterRequestFunc) *Request {
+	r.Filters = append(r.Filters, fn)
+	return r
+}
+
+// EnableNetworking enables the use real networking for the current mock.
+func (r *Request) EnableNetworking() *Request {
+	if r.Response != nil {
+		r.Response.UseNetwork = true
+	}
+	return r
+}
+
+// Reply defines the Response status code and returns the mock Response DSL.
+func (r *Request) Reply(status int) *Response {
+	return r.Response.Status(status)
+}
+
+// ReplyError defines the Response simulated error.
+func (r *Request) ReplyError(err error) *Response {
+	return r.Response.SetError(err)
+}
+
+// ReplyFunc allows the developer to define the mock response via a custom function.
+func (r *Request) ReplyFunc(replier func(*Response)) *Response {
+	replier(r.Response)
+	return r.Response
+}
+
+// See 2 (end of page 4) https://www.ietf.org/rfc/rfc2617.txt
+// "To receive authorization, the client sends the userid and password,
+// separated by a single colon (":") character, within a base64
+// encoded string in the credentials."
+// It is not meant to be urlencoded.
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}

--- a/vendor/gopkg.in/h2non/gock.v1/responder.go
+++ b/vendor/gopkg.in/h2non/gock.v1/responder.go
@@ -1,0 +1,87 @@
+package gock
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Responder builds a mock http.Response based on the given Response mock.
+func Responder(req *http.Request, mock *Response, res *http.Response) (*http.Response, error) {
+	// If error present, reply it
+	err := mock.Error
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		res = createResponse(req)
+	}
+
+	// Apply response filter
+	for _, filter := range mock.Filters {
+		if !filter(res) {
+			return res, nil
+		}
+	}
+
+	// Define mock status code
+	if mock.StatusCode != 0 {
+		res.Status = strconv.Itoa(mock.StatusCode) + " " + http.StatusText(mock.StatusCode)
+		res.StatusCode = mock.StatusCode
+	}
+
+	// Define headers by merging fields
+	res.Header = mergeHeaders(res, mock)
+
+	// Define mock body, if present
+	if len(mock.BodyBuffer) > 0 {
+		res.ContentLength = int64(len(mock.BodyBuffer))
+		res.Body = createReadCloser(mock.BodyBuffer)
+	}
+
+	// Apply response mappers
+	for _, mapper := range mock.Mappers {
+		if tres := mapper(res); tres != nil {
+			res = tres
+		}
+	}
+
+	// Sleep to simulate delay, if necessary
+	if mock.ResponseDelay > 0 {
+		time.Sleep(mock.ResponseDelay)
+	}
+
+	return res, err
+}
+
+// createResponse creates a new http.Response with default fields.
+func createResponse(req *http.Request) *http.Response {
+	return &http.Response{
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Proto:      "HTTP/1.1",
+		Request:    req,
+		Header:     make(http.Header),
+		Body:       createReadCloser([]byte{}),
+	}
+}
+
+// mergeHeaders copies the mock headers.
+func mergeHeaders(res *http.Response, mres *Response) http.Header {
+	for key, values := range mres.Header {
+		for _, value := range values {
+			res.Header.Add(key, value)
+		}
+	}
+	return res.Header
+}
+
+// createReadCloser creates an io.ReadCloser from a byte slice that is suitable for use as an
+// http response body.
+func createReadCloser(body []byte) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader(body))
+}

--- a/vendor/gopkg.in/h2non/gock.v1/response.go
+++ b/vendor/gopkg.in/h2non/gock.v1/response.go
@@ -1,0 +1,186 @@
+package gock
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// MapResponseFunc represents the required function interface impletemed by response mappers.
+type MapResponseFunc func(*http.Response) *http.Response
+
+// FilterResponseFunc represents the required function interface impletemed by response filters.
+type FilterResponseFunc func(*http.Response) bool
+
+// Response represents high-level HTTP fields to configure
+// and define HTTP responses intercepted by gock.
+type Response struct {
+	// Mock stores the parent mock reference for the current response mock used for method delegation.
+	Mock Mock
+
+	// Error stores the latest response configuration or injected error.
+	Error error
+
+	// UseNetwork enables the use of real network for the current mock.
+	UseNetwork bool
+
+	// StatusCode stores the response status code.
+	StatusCode int
+
+	// Headers stores the response headers.
+	Header http.Header
+
+	// Cookies stores the response cookie fields.
+	Cookies []*http.Cookie
+
+	// BodyBuffer stores the array of bytes to use as body.
+	BodyBuffer []byte
+
+	// ResponseDelay stores the simulated response delay.
+	ResponseDelay time.Duration
+
+	// Mappers stores the request functions mappers used for matching.
+	Mappers []MapResponseFunc
+
+	// Filters stores the request functions filters used for matching.
+	Filters []FilterResponseFunc
+}
+
+// NewResponse creates a new Response.
+func NewResponse() *Response {
+	return &Response{Header: make(http.Header)}
+}
+
+// Status defines the desired HTTP status code to reply in the current response.
+func (r *Response) Status(code int) *Response {
+	r.StatusCode = code
+	return r
+}
+
+// Type defines the response Content-Type MIME header field.
+// Supports type alias. E.g: json, xml, form, text...
+func (r *Response) Type(kind string) *Response {
+	mime := BodyTypeAliases[kind]
+	if mime != "" {
+		kind = mime
+	}
+	r.Header.Set("Content-Type", kind)
+	return r
+}
+
+// SetHeader sets a new header field in the mock response.
+func (r *Response) SetHeader(key, value string) *Response {
+	r.Header.Set(key, value)
+	return r
+}
+
+// AddHeader adds a new header field in the mock response
+// with out removing an existent one.
+func (r *Response) AddHeader(key, value string) *Response {
+	r.Header.Add(key, value)
+	return r
+}
+
+// SetHeaders sets a map of header fields in the mock response.
+func (r *Response) SetHeaders(headers map[string]string) *Response {
+	for key, value := range headers {
+		r.Header.Add(key, value)
+	}
+	return r
+}
+
+// Body sets the HTTP response body to be used.
+func (r *Response) Body(body io.Reader) *Response {
+	r.BodyBuffer, r.Error = ioutil.ReadAll(body)
+	return r
+}
+
+// BodyString defines the response body as string.
+func (r *Response) BodyString(body string) *Response {
+	r.BodyBuffer = []byte(body)
+	return r
+}
+
+// File defines the response body reading the data
+// from disk based on the file path string.
+func (r *Response) File(path string) *Response {
+	r.BodyBuffer, r.Error = ioutil.ReadFile(path)
+	return r
+}
+
+// JSON defines the response body based on a JSON based input.
+func (r *Response) JSON(data interface{}) *Response {
+	r.Header.Set("Content-Type", "application/json")
+	r.BodyBuffer, r.Error = readAndDecode(data, "json")
+	return r
+}
+
+// XML defines the response body based on a XML based input.
+func (r *Response) XML(data interface{}) *Response {
+	r.Header.Set("Content-Type", "application/xml")
+	r.BodyBuffer, r.Error = readAndDecode(data, "xml")
+	return r
+}
+
+// SetError defines the response simulated error.
+func (r *Response) SetError(err error) *Response {
+	r.Error = err
+	return r
+}
+
+// Delay defines the response simulated delay.
+// This feature is still experimental and will be improved in the future.
+func (r *Response) Delay(delay time.Duration) *Response {
+	r.ResponseDelay = delay
+	return r
+}
+
+// Map adds a new response mapper function to map http.Response before the matching process.
+func (r *Response) Map(fn MapResponseFunc) *Response {
+	r.Mappers = append(r.Mappers, fn)
+	return r
+}
+
+// Filter filters a new request filter function to filter http.Request before the matching process.
+func (r *Response) Filter(fn FilterResponseFunc) *Response {
+	r.Filters = append(r.Filters, fn)
+	return r
+}
+
+// EnableNetworking enables the use real networking for the current mock.
+func (r *Response) EnableNetworking() *Response {
+	r.UseNetwork = true
+	return r
+}
+
+// Done returns true if the mock was done and disabled.
+func (r *Response) Done() bool {
+	return r.Mock.Done()
+}
+
+func readAndDecode(data interface{}, kind string) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	switch data.(type) {
+	case string:
+		buf.WriteString(data.(string))
+	case []byte:
+		buf.Write(data.([]byte))
+	default:
+		var err error
+		if kind == "xml" {
+			err = xml.NewEncoder(buf).Encode(data)
+		} else {
+			err = json.NewEncoder(buf).Encode(data)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ioutil.ReadAll(buf)
+}

--- a/vendor/gopkg.in/h2non/gock.v1/store.go
+++ b/vendor/gopkg.in/h2non/gock.v1/store.go
@@ -1,0 +1,100 @@
+package gock
+
+import (
+	"sync"
+)
+
+// storeMutex is used interally for store synchronization.
+var storeMutex = sync.RWMutex{}
+
+// mocks is internally used to store registered mocks.
+var mocks = []Mock{}
+
+// Register registers a new mock in the current mocks stack.
+func Register(mock Mock) {
+	if Exists(mock) {
+		return
+	}
+
+	// Make ops thread safe
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	// Expose mock in request/response for delegation
+	mock.Request().Mock = mock
+	mock.Response().Mock = mock
+
+	// Registers the mock in the global store
+	mocks = append(mocks, mock)
+}
+
+// GetAll returns the current stack of registed mocks.
+func GetAll() []Mock {
+	storeMutex.RLock()
+	defer storeMutex.RUnlock()
+	return mocks
+}
+
+// Exists checks if the given Mock is already registered.
+func Exists(m Mock) bool {
+	storeMutex.RLock()
+	defer storeMutex.RUnlock()
+	for _, mock := range mocks {
+		if mock == m {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove removes a registered mock by reference.
+func Remove(m Mock) {
+	for i, mock := range mocks {
+		if mock == m {
+			storeMutex.Lock()
+			mocks = append(mocks[:i], mocks[i+1:]...)
+			storeMutex.Unlock()
+		}
+	}
+}
+
+// Flush flushes the current stack of registered mocks.
+func Flush() {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
+	mocks = []Mock{}
+}
+
+// Pending returns an slice of pending mocks.
+func Pending() []Mock {
+	Clean()
+	storeMutex.RLock()
+	defer storeMutex.RUnlock()
+	return mocks
+}
+
+// IsDone returns true if all the registered mocks has been triggered successfully.
+func IsDone() bool {
+	return !IsPending()
+}
+
+// IsPending returns true if there are pending mocks.
+func IsPending() bool {
+	return len(Pending()) > 0
+}
+
+// Clean cleans the mocks store removing disabled or obsolete mocks.
+func Clean() {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
+
+	buf := []Mock{}
+	for _, mock := range mocks {
+		if mock.Done() {
+			continue
+		}
+		buf = append(buf, mock)
+	}
+
+	mocks = buf
+}

--- a/vendor/gopkg.in/h2non/gock.v1/transport.go
+++ b/vendor/gopkg.in/h2non/gock.v1/transport.go
@@ -1,0 +1,112 @@
+package gock
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+)
+
+// var mutex *sync.Mutex = &sync.Mutex{}
+
+var (
+	// DefaultTransport stores the default mock transport used by gock.
+	DefaultTransport = NewTransport()
+
+	// NativeTransport stores the native net/http default transport
+	// in order to restore it when needed.
+	NativeTransport = http.DefaultTransport
+)
+
+var (
+	// ErrCannotMatch store the error returned in case of no matches.
+	ErrCannotMatch = errors.New("gock: cannot match any request")
+)
+
+// Transport implements http.RoundTripper, which fulfills single http requests issued by
+// an http.Client.
+//
+// gock's Transport encapsulates a given or default http.Transport for further
+// delegation, if needed.
+type Transport struct {
+	// mutex is used to make transport thread-safe of concurrent uses across goroutines.
+	mutex sync.Mutex
+
+	// Transport encapsulates the original http.RoundTripper transport interface for delegation.
+	Transport http.RoundTripper
+}
+
+// NewTransport creates a new *Transport with no responders.
+func NewTransport() *Transport {
+	return &Transport{Transport: NativeTransport}
+}
+
+// RoundTrip receives HTTP requests and routes them to the appropriate responder.  It is required to
+// implement the http.RoundTripper interface.  You will not interact with this directly, instead
+// the *http.Client you are using will call it for you.
+func (m *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Just act as a proxy if not intercepting
+	if !Intercepting() {
+		return m.Transport.RoundTrip(req)
+	}
+
+	m.mutex.Lock()
+	defer Clean()
+
+	var err error
+	var res *http.Response
+
+	// Match mock for the incoming http.Request
+	mock, err := MatchMock(req)
+	if err != nil {
+		m.mutex.Unlock()
+		return nil, err
+	}
+
+	// Invoke the observer with the intercepted http.Request and matched mock
+	if config.Observer != nil {
+		config.Observer(req, mock)
+	}
+
+	// Verify if should use real networking
+	networking := shouldUseNetwork(req, mock)
+	if !networking && mock == nil {
+		m.mutex.Unlock()
+		trackUnmatchedRequest(req)
+		return nil, ErrCannotMatch
+	}
+
+	// Ensure me unlock the mutex before building the response
+	m.mutex.Unlock()
+
+	// Perform real networking via original transport
+	if networking {
+		res, err = m.Transport.RoundTrip(req)
+		// In no mock matched, continue with the response
+		if err != nil || mock == nil {
+			return res, err
+		}
+	}
+
+	return Responder(req, mock.Response(), res)
+}
+
+// CancelRequest is a no-op function.
+func (m *Transport) CancelRequest(req *http.Request) {}
+
+func shouldUseNetwork(req *http.Request, mock Mock) bool {
+	if mock != nil && mock.Response().UseNetwork {
+		return true
+	}
+	if !config.Networking {
+		return false
+	}
+	if len(config.NetworkingFilters) == 0 {
+		return true
+	}
+	for _, filter := range config.NetworkingFilters {
+		if !filter(req) {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/gopkg.in/h2non/gock.v1/version.go
+++ b/vendor/gopkg.in/h2non/gock.v1/version.go
@@ -1,0 +1,4 @@
+package gock
+
+// Version defines the current package semantic version.
+const Version = "1.0.15"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,6 +44,8 @@ github.com/go-ini/ini
 github.com/godbus/dbus
 # github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c
 github.com/gsterjov/go-libsecret
+# github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542
+github.com/h2non/parth
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
@@ -94,5 +96,7 @@ golang.org/x/sys/windows
 # golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
+# gopkg.in/h2non/gock.v1 v1.0.15
+gopkg.in/h2non/gock.v1
 # gopkg.in/ini.v1 v1.42.0
 gopkg.in/ini.v1


### PR DESCRIPTION
create parralel lib2 that has "clients" and "providers" packages.

clients:
 - contains the components to interact with Okta
 - will cache your Okta session for you if a keyring is passed in

providers:
 - contains the components needed by Okta Providers. Currently this is
only the AWS SAML provider but could contain other providers in the
future.
 - will cache the session that this provider creates

Other than seperating logic this commit also introduces tests for
clients and providers as a starting point for more comprehensive test
coverage.