### PR TITLE
Return "password expired" when password is expired

### DIFF
--- a/lib/client/okta_test.go
+++ b/lib/client/okta_test.go
@@ -349,7 +349,7 @@ func TestOktaClientNoSessionCache(t *testing.T) {
 		// this would only test the unlikely case where the user doesn't have MFA setup.
 		// https://developer.okta.com/docs/reference/api/authn/#primary-authentication-with-public-application
 		err = oktaClient.AuthenticateUser()
-		assert.Equal(t, true, errors.Is(err, types.ErrInvalidCredentials), "verify we get an invalid creds error when password expired")
+		assert.Equal(t, true, errors.Is(err, types.ErrPasswordExpired), "verify we get an invalid creds error when password expired")
 	})
 
 	t.Run("session interface returns a reasonable error", func(t *testing.T) {

--- a/lib/client/types/errors.go
+++ b/lib/client/types/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrUnexpectedResponse = errors.New("we got an unexpected response")
 	ErrNotImplemented     = errors.New("not implemented")
 	ErrNotSupported       = errors.New("not supported")
+	ErrPasswordExpired    = errors.New("okta credentials are not valid: your user password is expired")
 )


### PR DESCRIPTION
- Return appropriate password expired message when authn succeeds but
  challengeMFA fails due to password expired.