### PR TITLE
bugfix: error codes are now propagated

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -237,9 +237,6 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	var waitStatus syscall.WaitStatus
 	if err := ecmd.Run(); err != nil {
-		if err != nil {
-			return err
-		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)
 			os.Exit(waitStatus.ExitStatus())


### PR DESCRIPTION
The exit code of the process that aws-okta is calling should be returned
as the return code of aws-okta

$ aws-okta exec profile1 -- bash -c "exit 124:
exit status 123
$ echo $?
123